### PR TITLE
Person history

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -46,6 +46,9 @@ public class Messages {
                 .append("; Affiliations: {");
         person.getAffiliations().forEach(builder::append);
         builder.append("}");
+        builder.append("; Affiliation History: {");
+        person.getAffiliationHistory().forEach(builder::append);
+        builder.append("}");
         return builder.toString();
     }
 

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -61,6 +61,7 @@ public class AddCommand extends Command {
 
         AuthenticateAffiliation.check(toAdd, model);
         AffiliationModifier.addAffiliations(toAdd.getAffiliations(), toAdd, model);
+        AffiliationModifier.addAffiliations(toAdd.getAffiliationHistory(), toAdd, model);
 
         model.addPerson(toAdd);
         return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(toAdd)));

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -61,7 +61,7 @@ public class AddCommand extends Command {
 
         AuthenticateAffiliation.check(toAdd, model);
         AffiliationModifier.addAffiliations(toAdd.getAffiliations(), toAdd, model);
-        AffiliationModifier.addAffiliations(toAdd.getAffiliationHistory(), toAdd, model);
+        AffiliationModifier.addAffiliationHistory(toAdd.getAffiliations(), toAdd, model);
 
         model.addPerson(toAdd);
         return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(toAdd)));

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -87,8 +87,9 @@ public class EditCommand extends Command {
         Set<Affiliation> updatedAffiliations = editPersonDescriptor
                 .getAffiliations().orElse(personToEdit.getAffiliations());
         Set<Affiliation> mergedAffiliationHistory = new HashSet<>(personToEdit.getAffiliationHistory());
-        mergedAffiliationHistory.addAll(updatedAffiliations); 
-        return updatedRole.generatePerson(updatedName, updatedPhone, updatedEmail, updatedAffiliations, mergedAffiliationHistory);
+        mergedAffiliationHistory.addAll(updatedAffiliations);
+        return updatedRole.generatePerson(updatedName, updatedPhone, updatedEmail,
+            updatedAffiliations, mergedAffiliationHistory);
     }
 
     @Override
@@ -254,7 +255,8 @@ public class EditCommand extends Command {
          * Returns {@code Optional#empty()} if {@code affiliations} is null.
          */
         public Optional<Set<Affiliation>> getAffiliationHistory() {
-            return (affiliationHistory != null) ? Optional.of(Collections.unmodifiableSet(affiliationHistory)) : Optional.empty();
+            return (affiliationHistory != null) ? Optional.of(Collections.unmodifiableSet(affiliationHistory))
+                : Optional.empty();
         }
         /**
          * Sets {@code affiliations} to this object's {@code affiliations}.
@@ -265,7 +267,8 @@ public class EditCommand extends Command {
         }
 
         /**
-         * Sets {@code affiliationHistory} to this object's {@code affiliationHistory}.
+         * Sets {@code affiliationHistory} and {@code affiliations} to
+         * this object's {@code affiliationHistory}.
          * A defensive copy of {@code affiliationHistory} is used internally.
          */
         public void setAffiliationHistory(Set<Affiliation> affiliationHistory, Set<Affiliation> affiliations) {
@@ -284,7 +287,8 @@ public class EditCommand extends Command {
          * A defensive copy of {@code affiliationHistory} is used internally.
          */
         public void setAffiliationHistory(Set<Affiliation> affiliationHistory) {
-            this.affiliationHistory = (affiliationHistory != null) ? new HashSet<>(affiliationHistory) : null;
+            this.affiliationHistory = (affiliationHistory != null)
+                ? new HashSet<>(affiliationHistory) : null;
         }
         /**
          * Adds {@code affiliations} to this object's {@code affiliations}.
@@ -296,7 +300,6 @@ public class EditCommand extends Command {
             }
             this.affiliationHistory.addAll(affiliations);
         }
-        
         @Override
         public boolean equals(Object other) {
             if (other == this) {

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -53,8 +53,10 @@ public class AddCommandParser implements Parser<AddCommand> {
         Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
         Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
         Role role = ParserUtil.parseRole(argMultimap.getValue(PREFIX_ROLE).get());
-        Set<Affiliation> affiliationList = ParserUtil.parseAffiliations(argMultimap.getAllValues(PREFIX_AFFILIATION));
-        Set<Affiliation> affiliationHistory = ParserUtil.parseAffiliations(argMultimap.getAllValues(PREFIX_AFFILIATION));
+        Set<Affiliation> affiliationList = ParserUtil
+            .parseAffiliations(argMultimap.getAllValues(PREFIX_AFFILIATION));
+        Set<Affiliation> affiliationHistory = ParserUtil
+            .parseAffiliations(argMultimap.getAllValues(PREFIX_AFFILIATION));
         Person person = role.generatePerson(name, phone, email, affiliationList, affiliationHistory);
 
         return new AddCommand(person);

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -54,7 +54,8 @@ public class AddCommandParser implements Parser<AddCommand> {
         Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
         Role role = ParserUtil.parseRole(argMultimap.getValue(PREFIX_ROLE).get());
         Set<Affiliation> affiliationList = ParserUtil.parseAffiliations(argMultimap.getAllValues(PREFIX_AFFILIATION));
-        Person person = role.generatePerson(name, phone, email, affiliationList);
+        Set<Affiliation> affiliationHistory = ParserUtil.parseAffiliations(argMultimap.getAllValues(PREFIX_AFFILIATION));
+        Person person = role.generatePerson(name, phone, email, affiliationList, affiliationHistory);
 
         return new AddCommand(person);
     }

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -62,6 +62,8 @@ public class EditCommandParser implements Parser<EditCommand> {
         }
         parseAffiliationsForEdit(argMultimap.getAllValues(PREFIX_AFFILIATION))
                 .ifPresent(editPersonDescriptor::setAffiliations);
+        parseAffiliationsForEdit(argMultimap.getAllValues(PREFIX_AFFILIATION))
+                .ifPresent(editPersonDescriptor::addAffiliationsToHistory);
 
         if (!editPersonDescriptor.isAnyFieldEdited()) {
             throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);

--- a/src/main/java/seedu/address/model/affiliation/AffiliationModifier.java
+++ b/src/main/java/seedu/address/model/affiliation/AffiliationModifier.java
@@ -34,6 +34,25 @@ public class AffiliationModifier {
     }
 
     /**
+     * Adds the affiliated person to the affiliation history for every
+     * person's affiliation history in the affiliation set provided.
+     *
+     * @param affiliationSet The affiliation set that contains all person that needs to add the affiliated person.
+     * @param affiliatedPerson The affiliated person to add to every person in the affiliation set.
+     * @param model The current model that is running.
+     */
+    public static void addAffiliationHistory(Set<Affiliation> affiliationSet, Person affiliatedPerson, Model model) {
+        requireAllNonNull(affiliationSet, affiliatedPerson, model);
+        ReadOnlyAddressBook addressBook = model.getAddressBook();
+
+        for (Affiliation affiliation: affiliationSet) {
+            Person otherAffiliatedPerson = AuthenticateAffiliation.findAffiliatedPerson(affiliation, addressBook);
+            assert otherAffiliatedPerson != null;
+            otherAffiliatedPerson.getAffiliationHistory().add(new Affiliation(affiliatedPerson.getName().fullName));
+        }
+    }
+
+    /**
      * Removes the affiliated person from the affiliations for every
      * person's affiliation in the affiliation set provided.
      *

--- a/src/main/java/seedu/address/model/person/Doctor.java
+++ b/src/main/java/seedu/address/model/person/Doctor.java
@@ -12,7 +12,8 @@ public class Doctor extends Person {
     /**
      * Every field must be present and not null.
      */
-    public Doctor(Name name, Phone phone, Email email, Set<Affiliation> affiliations, Set<Affiliation> affiliationHistory) {
+    public Doctor(Name name, Phone phone, Email email,
+        Set<Affiliation> affiliations, Set<Affiliation> affiliationHistory) {
         super(name, phone, email, new Role("Doctor"), affiliations, affiliationHistory);
     }
 

--- a/src/main/java/seedu/address/model/person/Doctor.java
+++ b/src/main/java/seedu/address/model/person/Doctor.java
@@ -12,6 +12,13 @@ public class Doctor extends Person {
     /**
      * Every field must be present and not null.
      */
+    public Doctor(Name name, Phone phone, Email email, Set<Affiliation> affiliations, Set<Affiliation> affiliationHistory) {
+        super(name, phone, email, new Role("Doctor"), affiliations, affiliationHistory);
+    }
+
+    /**
+     * Every field must be present and not null, except affiliationHistory.
+     */
     public Doctor(Name name, Phone phone, Email email, Set<Affiliation> affiliations) {
         super(name, phone, email, new Role("Doctor"), affiliations);
     }

--- a/src/main/java/seedu/address/model/person/Patient.java
+++ b/src/main/java/seedu/address/model/person/Patient.java
@@ -12,6 +12,13 @@ public class Patient extends Person {
     /**
      * Every field must be present and not null.
      */
+    public Patient(Name name, Phone phone, Email email, Set<Affiliation> affiliations, Set<Affiliation> affiliationHistory) {
+        super(name, phone, email, new Role("Patient"), affiliations, affiliationHistory);
+    }
+
+    /**
+     * Every field must be present and not null, except affiliationHistory.
+     */
     public Patient(Name name, Phone phone, Email email, Set<Affiliation> affiliations) {
         super(name, phone, email, new Role("Patient"), affiliations);
     }

--- a/src/main/java/seedu/address/model/person/Patient.java
+++ b/src/main/java/seedu/address/model/person/Patient.java
@@ -12,7 +12,8 @@ public class Patient extends Person {
     /**
      * Every field must be present and not null.
      */
-    public Patient(Name name, Phone phone, Email email, Set<Affiliation> affiliations, Set<Affiliation> affiliationHistory) {
+    public Patient(Name name, Phone phone, Email email,
+        Set<Affiliation> affiliations, Set<Affiliation> affiliationHistory) {
         super(name, phone, email, new Role("Patient"), affiliations, affiliationHistory);
     }
 

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -41,7 +41,8 @@ public class Person {
     /**
      * Every field must be present and not null.
      */
-    public Person(Name name, Phone phone, Email email, Role role, Set<Affiliation> affiliations, Set<Affiliation> affiliationHistory) {
+    public Person(Name name, Phone phone, Email email, Role role,
+        Set<Affiliation> affiliations, Set<Affiliation> affiliationHistory) {
         requireAllNonNull(name, phone, email, role, affiliations);
         this.name = name;
         this.phone = phone;

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -26,7 +26,7 @@ public class Person {
     private final Set<Affiliation> affiliationHistory = new HashSet<>();
 
     /**
-     * Every field must be present and not null.
+     * Every field must be present and not null, except affiliationHistory.
      */
     public Person(Name name, Phone phone, Email email, Role role, Set<Affiliation> affiliations) {
         requireAllNonNull(name, phone, email, role, affiliations);
@@ -36,6 +36,19 @@ public class Person {
         this.role = role;
         this.affiliations.addAll(affiliations);
         this.affiliationHistory.addAll(affiliations);
+    }
+
+    /**
+     * Every field must be present and not null.
+     */
+    public Person(Name name, Phone phone, Email email, Role role, Set<Affiliation> affiliations, Set<Affiliation> affiliationHistory) {
+        requireAllNonNull(name, phone, email, role, affiliations);
+        this.name = name;
+        this.phone = phone;
+        this.email = email;
+        this.role = role;
+        this.affiliations.addAll(affiliations);
+        this.affiliationHistory.addAll(affiliationHistory);
     }
 
     public Name getName() {

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -23,6 +23,7 @@ public class Person {
     // Data fields
     private final Role role;
     private final Set<Affiliation> affiliations = new HashSet<>();
+    private final Set<Affiliation> affiliationHistory = new HashSet<>();
 
     /**
      * Every field must be present and not null.
@@ -34,6 +35,7 @@ public class Person {
         this.email = email;
         this.role = role;
         this.affiliations.addAll(affiliations);
+        this.affiliationHistory.addAll(affiliations);
     }
 
     public Name getName() {
@@ -57,6 +59,14 @@ public class Person {
      */
     public Set<Affiliation> getAffiliations() {
         return affiliations;
+    }
+
+    /**
+     * Returns an affiliation history set.
+     * @return affiliationHistory
+     */
+    public Set<Affiliation> getAffiliationHistory() {
+        return affiliationHistory;
     }
 
     /**
@@ -92,13 +102,14 @@ public class Person {
                 && phone.equals(otherPerson.phone)
                 && email.equals(otherPerson.email)
                 && role.equals(otherPerson.role)
-                && affiliations.equals(otherPerson.affiliations);
+                && affiliations.equals(otherPerson.affiliations)
+                && affiliationHistory.equals(otherPerson.affiliationHistory);
     }
 
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(name, phone, email, role, affiliations);
+        return Objects.hash(name, phone, email, role, affiliations, affiliationHistory);
     }
 
     public ToStringBuilder getStringBuilderRepresentation() {
@@ -107,7 +118,8 @@ public class Person {
                 .add("phone", phone)
                 .add("email", email)
                 .add("role", role)
-                .add("affiliations", affiliations);
+                .add("affiliations", affiliations)
+                .add("affiliationHistory", affiliationHistory);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Role.java
+++ b/src/main/java/seedu/address/model/person/Role.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -52,6 +53,24 @@ public class Role {
     }
 
     /**
+     * Returns person with its particular type based on the role.
+     *
+     * @param name Name of person.
+     * @param phone Phone of person.
+     * @param email Email of person.
+     * @param affiliationList Affiliations of person.
+     */
+    public Person generatePerson(Name name, Phone phone, Email email, Set<Affiliation> affiliationList, Set<Affiliation> affiliationHistory) {
+        if (value.toUpperCase().equals(Type.DOCTOR.name())) {
+            return new Doctor(name, phone, email, affiliationList, affiliationHistory);
+        } else if (value.toUpperCase().equals(Type.PATIENT.name())) {
+            return new Patient(name, phone, email, affiliationList, affiliationHistory);
+        } else {
+            return null;
+        }
+    }
+
+        /**
      * Returns person with its particular type based on the role.
      *
      * @param name Name of person.

--- a/src/main/java/seedu/address/model/person/Role.java
+++ b/src/main/java/seedu/address/model/person/Role.java
@@ -4,7 +4,6 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -60,7 +59,8 @@ public class Role {
      * @param email Email of person.
      * @param affiliationList Affiliations of person.
      */
-    public Person generatePerson(Name name, Phone phone, Email email, Set<Affiliation> affiliationList, Set<Affiliation> affiliationHistory) {
+    public Person generatePerson(Name name, Phone phone, Email email,
+        Set<Affiliation> affiliationList, Set<Affiliation> affiliationHistory) {
         if (value.toUpperCase().equals(Type.DOCTOR.name())) {
             return new Doctor(name, phone, email, affiliationList, affiliationHistory);
         } else if (value.toUpperCase().equals(Type.PATIENT.name())) {
@@ -70,7 +70,7 @@ public class Role {
         }
     }
 
-        /**
+    /**
      * Returns person with its particular type based on the role.
      *
      * @param name Name of person.

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -103,7 +103,7 @@ class JsonAdaptedPerson {
         final Role modelRole = new Role(role);
 
         final Set<Affiliation> modelAffiliations = new HashSet<>(personAffiliations);
-        return new Person(modelName, modelPhone, modelEmail, modelRole, modelAffiliations);
+        return modelRole.generatePerson(modelName, modelPhone, modelEmail, modelAffiliations);
     }
 
 }

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -29,6 +29,7 @@ class JsonAdaptedPerson {
     private final String email;
     private final String role;
     private final List<JsonAdaptedAffiliation> affiliations = new ArrayList<>();
+    private final List<JsonAdaptedAffiliation> affiliationHistory = new ArrayList<>();
 
     /**
      * Constructs a {@code JsonAdaptedPerson} with the given person details.
@@ -36,13 +37,17 @@ class JsonAdaptedPerson {
     @JsonCreator
     public JsonAdaptedPerson(@JsonProperty("name") String name, @JsonProperty("phone") String phone,
                              @JsonProperty("email") String email, @JsonProperty("role") String role,
-                             @JsonProperty("affiliations") List<JsonAdaptedAffiliation> affiliations) {
+                             @JsonProperty("affiliations") List<JsonAdaptedAffiliation> affiliations,
+                             @JsonProperty("affiliationHistory") List<JsonAdaptedAffiliation> affiliationHistory) {
         this.name = name;
         this.phone = phone;
         this.email = email;
         this.role = role;
         if (affiliations != null) {
             this.affiliations.addAll(affiliations);
+        }
+        if (affiliationHistory != null) {
+            this.affiliationHistory.addAll(affiliationHistory);
         }
     }
 
@@ -57,6 +62,9 @@ class JsonAdaptedPerson {
         affiliations.addAll(source.getAffiliations().stream()
                 .map(JsonAdaptedAffiliation::new)
                 .collect(Collectors.toList()));
+        affiliationHistory.addAll(source.getAffiliationHistory().stream()
+                .map(JsonAdaptedAffiliation::new)
+                .collect(Collectors.toList()));
     }
 
     /**
@@ -69,7 +77,10 @@ class JsonAdaptedPerson {
         for (JsonAdaptedAffiliation affiliation : affiliations) {
             personAffiliations.add(affiliation.toModelType());
         }
-
+        final List<Affiliation> personAffiliationHistory = new ArrayList<>();
+        for (JsonAdaptedAffiliation affiliation : affiliationHistory) {
+            personAffiliationHistory.add(affiliation.toModelType());
+        }
         if (name == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName()));
         }
@@ -103,7 +114,8 @@ class JsonAdaptedPerson {
         final Role modelRole = new Role(role);
 
         final Set<Affiliation> modelAffiliations = new HashSet<>(personAffiliations);
-        return modelRole.generatePerson(modelName, modelPhone, modelEmail, modelAffiliations);
+        final Set<Affiliation> modelAffiliationHistory = new HashSet<>(personAffiliationHistory);
+        return new Person(modelName, modelPhone, modelEmail, modelRole, modelAffiliations, modelAffiliationHistory);
     }
 
 }

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -65,11 +65,5 @@ public class PersonCard extends UiPart<Region> {
             .map(affiliation -> affiliation.affiliationName)
             .collect(Collectors.joining(", "));
         affiliationHistoryPane.getChildren().add(new Label(affiliationHistoryText));
-        // person.getAffiliations().stream()
-        //         .sorted(Comparator.comparing(affiliation -> affiliation.affiliationName))
-        //         .forEach(affiliation -> affiliations.getChildren().add(new Label(affiliation.affiliationName)));
-        // person.getAffiliationHistory().stream()
-        //         .sorted(Comparator.comparing(affiliation -> affiliation.affiliationName))
-        //         .forEach(affiliation -> affiliationHistoryPane.getChildren().add(new Label(affiliation.affiliationName)));
     }
 }

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -1,6 +1,7 @@
 package seedu.address.ui;
 
 import java.util.Comparator;
+import java.util.stream.Collectors;
 
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
@@ -40,6 +41,8 @@ public class PersonCard extends UiPart<Region> {
     private Label email;
     @FXML
     private FlowPane affiliations;
+    @FXML
+    private FlowPane affiliationHistoryPane;
 
     /**
      * Creates a {@code PersonCode} with the given {@code Person} and index to display.
@@ -52,8 +55,21 @@ public class PersonCard extends UiPart<Region> {
         phone.setText(person.getPhone().value);
         role.setText(person.getRole().value);
         email.setText(person.getEmail().value);
-        person.getAffiliations().stream()
-                .sorted(Comparator.comparing(affiliation -> affiliation.affiliationName))
-                .forEach(affiliation -> affiliations.getChildren().add(new Label(affiliation.affiliationName)));
+        String affiliationsText = person.getAffiliations().stream()
+            .sorted(Comparator.comparing(affiliation -> affiliation.affiliationName))
+            .map(affiliation -> affiliation.affiliationName)
+            .collect(Collectors.joining(", "));
+        affiliations.getChildren().add(new Label(affiliationsText));
+        String affiliationHistoryText = person.getAffiliationHistory().stream()
+            .sorted(Comparator.comparing(affiliation -> affiliation.affiliationName))
+            .map(affiliation -> affiliation.affiliationName)
+            .collect(Collectors.joining(", "));
+        affiliationHistoryPane.getChildren().add(new Label(affiliationHistoryText));
+        // person.getAffiliations().stream()
+        //         .sorted(Comparator.comparing(affiliation -> affiliation.affiliationName))
+        //         .forEach(affiliation -> affiliations.getChildren().add(new Label(affiliation.affiliationName)));
+        // person.getAffiliationHistory().stream()
+        //         .sorted(Comparator.comparing(affiliation -> affiliation.affiliationName))
+        //         .forEach(affiliation -> affiliationHistoryPane.getChildren().add(new Label(affiliation.affiliationName)));
     }
 }

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -28,6 +28,7 @@
         <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
       </HBox>
       <FlowPane fx:id="affiliations" />
+      <FlowPane fx:id="affiliationHistoryPane" />
       <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
       <Label fx:id="role" styleClass="cell_small_label" text="\$role" />
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" />

--- a/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
@@ -4,7 +4,8 @@
     "phone": "94351253",
     "email": "alice@example.com",
     "role": "Doctor",
-    "affiliations": [ "friends" ]
+    "affiliations": [ "friends" ],
+    "affiliationHistory": [ "friends" ]
   }, {
     "name": "Alice Pauline",
     "phone": "94351253",

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -5,42 +5,49 @@
     "phone" : "94351253",
     "email" : "alice@example.com",
     "role" : "Doctor",
-    "affiliations" : [ "Benson Meier" ]
+    "affiliations" : [ "Benson Meier" ],
+    "affiliationHistory" : [ "Benson Meier" ]
   }, {
     "name" : "Benson Meier",
     "phone" : "98765432",
     "email" : "johnd@example.com",
     "role" : "Patient",
-    "affiliations" : [ "Alice Pauline", "Carl Kurz" ]
+    "affiliations" : [ "Alice Pauline", "Carl Kurz" ],
+    "affiliationHistory" : [ "Alice Pauline", "Carl Kurz" ]
   }, {
     "name" : "Carl Kurz",
     "phone" : "95352563",
     "email" : "heinz@example.com",
     "role" : "Doctor",
-    "affiliations" : [ ]
+    "affiliations" : [ ],
+    "affiliationHistory" : [ ]
   }, {
     "name" : "Daniel Meier",
     "phone" : "87652533",
     "email" : "cornelia@example.com",
     "role" : "Patient",
-    "affiliations" : [ ]
+    "affiliations" : [ ],
+    "affiliationHistory" : [ ]
   }, {
     "name" : "Elle Meyer",
     "phone" : "9482224",
     "email" : "werner@example.com",
     "role" : "Doctor",
-    "affiliations" : [ ]
+    "affiliations" : [ ],
+    "affiliationHistory" : [ ]
   }, {
     "name" : "Fiona Kunz",
     "phone" : "9482427",
     "email" : "lydia@example.com",
     "role" : "Patient",
-    "affiliations" : [ ]
+    "affiliations" : [ ],
+    "affiliationHistory" : [ ]
   }, {
     "name" : "George Best",
     "phone" : "9482442",
     "email" : "anna@example.com",
     "role" : "Doctor",
-    "affiliations" : [ ]
+    "affiliations" : [ ],
+    "affiliationHistory" : [ ]
   } ]
 }

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -66,10 +66,12 @@ public class CommandTestUtil {
     static {
         DESC_AMY = new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY)
                 .withPhone(VALID_PHONE_AMY).withEmail(VALID_EMAIL_AMY).withRole(VALID_ROLE_AMY)
-                .withAffiliations(VALID_AFFILIATION_BOB).build();
+                .withAffiliations(VALID_AFFILIATION_BOB)
+                .withAffiliationHistory(VALID_AFFILIATION_BOB).build();
         DESC_BOB = new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB)
                 .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB).withRole(VALID_ROLE_BOB)
-                .withAffiliations(VALID_AFFILIATION_AMY, VALID_AFFILIATION_BOB).build();
+                .withAffiliations(VALID_AFFILIATION_AMY, VALID_AFFILIATION_BOB)
+                .withAffiliationHistory(VALID_AFFILIATION_AMY, VALID_AFFILIATION_BOB).build();
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -37,7 +37,7 @@ public class EditCommandTest {
 
     @Test
     public void execute_allFieldsSpecifiedUnfilteredList_success() {
-        Person editedPerson = new PersonBuilder().build();
+        Person editedPerson = new PersonBuilder().withAffiliationHistory("Benson Meier").build();
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(editedPerson).build();
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
 
@@ -55,10 +55,12 @@ public class EditCommandTest {
 
         PersonBuilder personInList = new PersonBuilder(lastPerson);
         Person editedPerson = personInList.withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
-                .withAffiliations(VALID_AFFILIATION_DANIEL).build();
+                .withAffiliations(VALID_AFFILIATION_DANIEL)
+                .withAffiliationHistory(VALID_AFFILIATION_DANIEL).build();
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB)
-                .withPhone(VALID_PHONE_BOB).withAffiliations(VALID_AFFILIATION_DANIEL).build();
+                .withPhone(VALID_PHONE_BOB).withAffiliations(VALID_AFFILIATION_DANIEL)
+                .withAffiliationHistory(VALID_AFFILIATION_DANIEL).build();
         EditCommand editCommand = new EditCommand(indexLastPerson, descriptor);
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));

--- a/src/test/java/seedu/address/logic/commands/EditPersonDescriptorTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditPersonDescriptorTest.java
@@ -53,7 +53,8 @@ public class EditPersonDescriptorTest {
         assertFalse(DESC_AMY.equals(editedAmy));
 
         // different affiliations -> returns false
-        editedAmy = new EditPersonDescriptorBuilder(DESC_AMY).withAffiliations(VALID_AFFILIATION_AMY).build();
+        editedAmy = new EditPersonDescriptorBuilder(DESC_AMY).withAffiliations(VALID_AFFILIATION_AMY)
+        .withAffiliationHistory(VALID_AFFILIATION_AMY).build();
         assertFalse(DESC_AMY.equals(editedAmy));
     }
 
@@ -65,7 +66,8 @@ public class EditPersonDescriptorTest {
                 + editPersonDescriptor.getPhone().orElse(null) + ", email="
                 + editPersonDescriptor.getEmail().orElse(null) + ", role="
                 + editPersonDescriptor.getRole().orElse(null) + ", affiliations="
-                + editPersonDescriptor.getAffiliations().orElse(null) + "}";
+                + editPersonDescriptor.getAffiliations().orElse(null) + ", affiliationHistory="
+                + editPersonDescriptor.getAffiliationHistory().orElse(null) + "}";
         assertEquals(expected, editPersonDescriptor.toString());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/EditPersonDescriptorTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditPersonDescriptorTest.java
@@ -11,9 +11,13 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ROLE_BOB;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
+import seedu.address.model.affiliation.Affiliation;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 
 public class EditPersonDescriptorTest {
@@ -56,6 +60,47 @@ public class EditPersonDescriptorTest {
         editedAmy = new EditPersonDescriptorBuilder(DESC_AMY).withAffiliations(VALID_AFFILIATION_AMY)
         .withAffiliationHistory(VALID_AFFILIATION_AMY).build();
         assertFalse(DESC_AMY.equals(editedAmy));
+    }
+
+    @Test
+    public void setAffiliationHistory_validAffiliationHistory_setsHistoryCorrectly() {
+        EditPersonDescriptor descriptor = new EditPersonDescriptor();
+        Affiliation affiliation1 = new Affiliation("Affiliation1");
+        Affiliation affiliation2 = new Affiliation("Affiliation2");
+        Set<Affiliation> affiliations = new HashSet<>();
+        affiliations.add(affiliation1);
+        affiliations.add(affiliation2);
+        descriptor.setAffiliationHistory(affiliations);
+
+        assertTrue(descriptor.getAffiliationHistory().isPresent());
+        assertEquals(affiliations, descriptor.getAffiliationHistory().get());
+
+        Affiliation affiliation3 = new Affiliation("Affiliation3");
+        affiliations.add(affiliation3);
+        descriptor.setAffiliationHistory(affiliations, affiliations);
+        assertTrue(descriptor.getAffiliationHistory().isPresent());
+        assertEquals(affiliations, descriptor.getAffiliationHistory().get());
+    }
+
+    @Test
+    public void addAffiliationsToHistory_validAffiliations_addsToHistoryCorrectly() {
+        EditPersonDescriptor descriptor = new EditPersonDescriptor();
+        Affiliation affiliation1 = new Affiliation("Affiliation1");
+        Affiliation affiliation2 = new Affiliation("Affiliation2");
+        Set<Affiliation> initialHistory = new HashSet<>();
+        initialHistory.add(affiliation1);
+        initialHistory.add(affiliation2);
+        descriptor.setAffiliationHistory(initialHistory);
+        Affiliation affiliation3 = new Affiliation("Affiliation3");
+        Affiliation affiliation4 = new Affiliation("Affiliation4");
+        Set<Affiliation> newAffiliations = new HashSet<>();
+        newAffiliations.add(affiliation3);
+        newAffiliations.add(affiliation4);
+        descriptor.addAffiliationsToHistory(newAffiliations);
+        assertTrue(descriptor.getAffiliationHistory().isPresent());
+        Set<Affiliation> expectedHistory = new HashSet<>(initialHistory);
+        expectedHistory.addAll(newAffiliations);
+        assertEquals(expectedHistory, descriptor.getAffiliationHistory().get());
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -51,7 +51,7 @@ public class AddCommandParserTest {
     @Test
     public void parse_allFieldsPresent_success() {
         Person expectedPerson = new PersonBuilder(BOB).withAffiliations(VALID_AFFILIATION_BOB)
-        .withAffiliationHistory(VALID_AFFILIATION_BOB).build();
+                .withAffiliationHistory(VALID_AFFILIATION_BOB).build();
 
         // whitespace only preamble
         assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -50,7 +50,8 @@ public class AddCommandParserTest {
 
     @Test
     public void parse_allFieldsPresent_success() {
-        Person expectedPerson = new PersonBuilder(BOB).withAffiliations(VALID_AFFILIATION_BOB).build();
+        Person expectedPerson = new PersonBuilder(BOB).withAffiliations(VALID_AFFILIATION_BOB)
+        .withAffiliationHistory(VALID_AFFILIATION_BOB).build();
 
         // whitespace only preamble
         assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
@@ -60,6 +61,7 @@ public class AddCommandParserTest {
         // multiple affiliations - all accepted
         Person expectedPersonMultipleAffiliations = new PersonBuilder(BOB)
                 .withAffiliations(VALID_AFFILIATION_BOB, VALID_AFFILIATION_AMY)
+                .withAffiliationHistory(VALID_AFFILIATION_BOB, VALID_AFFILIATION_AMY)
                 .build();
         assertParseSuccess(parser,
                 NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -116,7 +116,8 @@ public class EditCommandParserTest {
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY)
                 .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_AMY).withRole(VALID_ROLE_AMY)
-                .withAffiliations(VALID_AFFILIATION_AMY, VALID_AFFILIATION_BOB).build();
+                .withAffiliations(VALID_AFFILIATION_AMY, VALID_AFFILIATION_BOB)
+                .withAffiliationHistory(VALID_AFFILIATION_AMY, VALID_AFFILIATION_BOB).build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
@@ -163,7 +164,8 @@ public class EditCommandParserTest {
 
         // affiliations
         userInput = targetIndex.getOneBased() + AFFILIATION_DESC_BOB;
-        descriptor = new EditPersonDescriptorBuilder().withAffiliations(VALID_AFFILIATION_BOB).build();
+        descriptor = new EditPersonDescriptorBuilder().withAffiliations(VALID_AFFILIATION_BOB)
+        .withAffiliationHistory(VALID_AFFILIATION_BOB).build();
         expectedCommand = new EditCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
     }

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -48,6 +48,7 @@ public class AddressBookTest {
         // Two persons with the same identity fields
         Person editedAlice = new PersonBuilder(ALICE).withRole(VALID_ROLE_BOB)
                 .withAffiliations(VALID_AFFILIATION_AMY)
+                .withAffiliationHistory(VALID_AFFILIATION_AMY)
                 .build();
         List<Person> newPersons = Arrays.asList(ALICE, editedAlice);
         AddressBookStub newData = new AddressBookStub(newPersons);
@@ -76,6 +77,7 @@ public class AddressBookTest {
         addressBook.addPerson(ALICE);
         Person editedAlice = new PersonBuilder(ALICE).withRole(VALID_ROLE_BOB)
                 .withAffiliations(VALID_AFFILIATION_AMY)
+                .withAffiliationHistory(VALID_AFFILIATION_AMY)
                 .build();
         assertTrue(addressBook.hasPerson(editedAlice));
     }

--- a/src/test/java/seedu/address/model/affiliation/AffiliationCheckerTest.java
+++ b/src/test/java/seedu/address/model/affiliation/AffiliationCheckerTest.java
@@ -33,6 +33,7 @@ public class AffiliationCheckerTest {
                 .withName(VALID_NAME_AMY)
                 .withRole(VALID_ROLE_BOB)
                 .withAffiliations(VALID_AFFILIATION_BOB)
+                .withAffiliationHistory(VALID_AFFILIATION_BOB)
                 .build();
         assertThrows(AffiliationPersonNotFoundException.class, () -> AuthenticateAffiliation.check(person, model));
     }
@@ -43,6 +44,7 @@ public class AffiliationCheckerTest {
                 .withName(VALID_NAME_ALICE)
                 .withRole(VALID_ROLE_BOB)
                 .withAffiliations(VALID_NAME_ALICE)
+                .withAffiliationHistory(VALID_NAME_ALICE)
                 .build();
         assertThrows(SamePersonAffiliationException.class, () -> AuthenticateAffiliation.check(person, model));
     }
@@ -53,6 +55,7 @@ public class AffiliationCheckerTest {
                 .withName(VALID_NAME_BOB)
                 .withRole(VALID_ROLE_AMY)
                 .withAffiliations(VALID_NAME_ALICE)
+                .withAffiliationHistory(VALID_NAME_ALICE)
                 .build();
         assertThrows(SameRoleAffiliationException.class, () -> AuthenticateAffiliation.check(person, model));
     }
@@ -63,6 +66,7 @@ public class AffiliationCheckerTest {
                 .withName(VALID_NAME_BOB)
                 .withRole(VALID_ROLE_BOB)
                 .withAffiliations(VALID_NAME_ALICE)
+                .withAffiliationHistory(VALID_NAME_ALICE)
                 .build();
         try {
             assertTrue(AuthenticateAffiliation.check(person, model));

--- a/src/test/java/seedu/address/model/affiliation/AffiliationModifierTest.java
+++ b/src/test/java/seedu/address/model/affiliation/AffiliationModifierTest.java
@@ -21,7 +21,8 @@ public class AffiliationModifierTest {
     @Test
     public void addAffiliation_validParam_success() {
         Person doctorA = new DoctorBuilder().withName("Alice").build();
-        Person patientB = new PatientBuilder().withName("Bob").withAffiliations("Alice").build();
+        Person patientB = new PatientBuilder().withName("Bob").withAffiliations("Alice")
+        .withAffiliationHistory("Alice").build();
         model.addPerson(doctorA);
         model.addPerson(patientB);
 
@@ -31,8 +32,10 @@ public class AffiliationModifierTest {
 
     @Test
     public void removeAffiliation_validParam_success() {
-        Person doctorA = new DoctorBuilder().withName("Alice").withAffiliations("Bob").build();
-        Person patientB = new PatientBuilder().withName("Bob").withAffiliations("Alice").build();
+        Person doctorA = new DoctorBuilder().withName("Alice").withAffiliations("Bob")
+        .withAffiliationHistory("Bob").build();
+        Person patientB = new PatientBuilder().withName("Bob").withAffiliations("Alice")
+        .withAffiliationHistory("Alice").build();
         model.addPerson(doctorA);
         model.addPerson(patientB);
 
@@ -42,8 +45,10 @@ public class AffiliationModifierTest {
 
     @Test
     public void nameChangeAffiliation_validParam_success() {
-        Person doctorA = new DoctorBuilder().withName("Alice").withAffiliations("Bob").build();
-        Person patientB = new PatientBuilder().withName("Bob").withAffiliations("Alice").build();
+        Person doctorA = new DoctorBuilder().withName("Alice").withAffiliations("Bob")
+        .withAffiliationHistory("Bob").build();
+        Person patientB = new PatientBuilder().withName("Bob").withAffiliations("Alice")
+        .withAffiliationHistory("Alice").build();
         model.addPerson(doctorA);
         model.addPerson(patientB);
         Name newName = new Name("Ben");

--- a/src/test/java/seedu/address/model/affiliation/AffiliationModifierTest.java
+++ b/src/test/java/seedu/address/model/affiliation/AffiliationModifierTest.java
@@ -4,6 +4,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
 import org.junit.jupiter.api.Test;
 
 import seedu.address.model.Model;
@@ -22,7 +26,7 @@ public class AffiliationModifierTest {
     public void addAffiliation_validParam_success() {
         Person doctorA = new DoctorBuilder().withName("Alice").build();
         Person patientB = new PatientBuilder().withName("Bob").withAffiliations("Alice")
-        .withAffiliationHistory("Alice").build();
+            .withAffiliationHistory("Alice").build();
         model.addPerson(doctorA);
         model.addPerson(patientB);
 
@@ -31,11 +35,28 @@ public class AffiliationModifierTest {
     }
 
     @Test
+    public void addAffiliationHistory_validParam_success() {
+        Person doctorAlice = new DoctorBuilder().withName("Alice").build();
+        Person doctorCharlie = new DoctorBuilder().withName("Charlie").build();
+        Person patientBob = new PatientBuilder().withName("Bob")
+            .withAffiliations("Alice", "Charlie")
+            .withAffiliationHistory("Alice", "Charlie").build();
+        model.addPerson(doctorAlice);
+        model.addPerson(doctorCharlie);
+        model.addPerson(patientBob);
+        Set<Affiliation> affiliationSet = new HashSet<>(Arrays.asList(new Affiliation("Alice"),
+            new Affiliation("Charlie")));
+        AffiliationModifier.addAffiliationHistory(affiliationSet, patientBob, model);
+        assertTrue(doctorAlice.getAffiliationHistory().contains(new Affiliation(patientBob.getName().fullName)));
+        assertTrue(doctorCharlie.getAffiliationHistory().contains(new Affiliation(patientBob.getName().fullName)));
+    }
+
+    @Test
     public void removeAffiliation_validParam_success() {
         Person doctorA = new DoctorBuilder().withName("Alice").withAffiliations("Bob")
-        .withAffiliationHistory("Bob").build();
+            .withAffiliationHistory("Bob").build();
         Person patientB = new PatientBuilder().withName("Bob").withAffiliations("Alice")
-        .withAffiliationHistory("Alice").build();
+            .withAffiliationHistory("Alice").build();
         model.addPerson(doctorA);
         model.addPerson(patientB);
 
@@ -46,9 +67,9 @@ public class AffiliationModifierTest {
     @Test
     public void nameChangeAffiliation_validParam_success() {
         Person doctorA = new DoctorBuilder().withName("Alice").withAffiliations("Bob")
-        .withAffiliationHistory("Bob").build();
+            .withAffiliationHistory("Bob").build();
         Person patientB = new PatientBuilder().withName("Bob").withAffiliations("Alice")
-        .withAffiliationHistory("Alice").build();
+            .withAffiliationHistory("Alice").build();
         model.addPerson(doctorA);
         model.addPerson(patientB);
         Name newName = new Name("Ben");

--- a/src/test/java/seedu/address/model/person/DoctorTest.java
+++ b/src/test/java/seedu/address/model/person/DoctorTest.java
@@ -34,7 +34,8 @@ public class DoctorTest {
 
         // same name, all other attributes different -> returns true
         Doctor editedAlice = new DoctorBuilder(ALICE).withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB)
-                .withAffiliations(VALID_AFFILIATION_AMY).build();
+                .withAffiliations(VALID_AFFILIATION_AMY)
+                .withAffiliationHistory(VALID_AFFILIATION_AMY).build();
         assertTrue(ALICE.isSamePerson(editedAlice));
 
         // different name, all other attributes same -> returns false
@@ -82,7 +83,8 @@ public class DoctorTest {
         assertFalse(ALICE.equals(editedAlice));
 
         // different affiliations -> returns false
-        editedAlice = new DoctorBuilder(ALICE).withAffiliations(VALID_AFFILIATION_AMY).build();
+        editedAlice = new DoctorBuilder(ALICE).withAffiliations(VALID_AFFILIATION_AMY)
+        .withAffiliationHistory(VALID_AFFILIATION_AMY).build();
         assertFalse(ALICE.equals(editedAlice));
     }
 
@@ -90,7 +92,7 @@ public class DoctorTest {
     public void toStringMethod() {
         String expected = Doctor.class.getCanonicalName() + "{name=" + ALICE.getName() + ", phone=" + ALICE.getPhone()
                 + ", email=" + ALICE.getEmail() + ", role=" + ALICE.getRole() + ", affiliations="
-                + ALICE.getAffiliations() + "}";
+                + ALICE.getAffiliations() + ", affiliationHistory=" + ALICE.getAffiliationHistory() +"}";
         assertEquals(expected, ALICE.toString());
     }
 }

--- a/src/test/java/seedu/address/model/person/DoctorTest.java
+++ b/src/test/java/seedu/address/model/person/DoctorTest.java
@@ -92,7 +92,7 @@ public class DoctorTest {
     public void toStringMethod() {
         String expected = Doctor.class.getCanonicalName() + "{name=" + ALICE.getName() + ", phone=" + ALICE.getPhone()
                 + ", email=" + ALICE.getEmail() + ", role=" + ALICE.getRole() + ", affiliations="
-                + ALICE.getAffiliations() + ", affiliationHistory=" + ALICE.getAffiliationHistory() +"}";
+                + ALICE.getAffiliations() + ", affiliationHistory=" + ALICE.getAffiliationHistory() + "}";
         assertEquals(expected, ALICE.toString());
     }
 }

--- a/src/test/java/seedu/address/model/person/PatientTest.java
+++ b/src/test/java/seedu/address/model/person/PatientTest.java
@@ -34,7 +34,8 @@ public class PatientTest {
 
         // same name, all other attributes different -> returns true
         Patient editedAlice = new PatientBuilder(ALICE).withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB)
-                .withAffiliations(VALID_AFFILIATION_AMY).build();
+                .withAffiliations(VALID_AFFILIATION_AMY)
+                .withAffiliationHistory(VALID_AFFILIATION_AMY).build();
         assertTrue(ALICE.isSamePerson(editedAlice));
 
         // different name, all other attributes same -> returns false
@@ -82,7 +83,8 @@ public class PatientTest {
         assertFalse(ALICE.equals(editedAlice));
 
         // different affiliations -> returns false
-        editedAlice = new PatientBuilder(ALICE).withAffiliations(VALID_AFFILIATION_AMY).build();
+        editedAlice = new PatientBuilder(ALICE).withAffiliations(VALID_AFFILIATION_AMY)
+        .withAffiliationHistory(VALID_AFFILIATION_AMY).build();
         assertFalse(ALICE.equals(editedAlice));
     }
 
@@ -90,7 +92,7 @@ public class PatientTest {
     public void toStringMethod() {
         String expected = Patient.class.getCanonicalName() + "{name=" + ALICE.getName() + ", phone=" + ALICE.getPhone()
                 + ", email=" + ALICE.getEmail() + ", role=" + ALICE.getRole() + ", affiliations="
-                + ALICE.getAffiliations() + "}";
+                + ALICE.getAffiliations() + ", affiliationHistory=" + ALICE.getAffiliationHistory() + "}";
         assertEquals(expected, ALICE.toString());
     }
 }

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -35,7 +35,8 @@ public class PersonTest {
 
         // same name, all other attributes different -> returns true
         Person editedAlice = new PersonBuilder(ALICE).withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB)
-                .withRole(VALID_ROLE_BOB).withAffiliations(VALID_AFFILIATION_AMY).build();
+                .withRole(VALID_ROLE_BOB).withAffiliations(VALID_AFFILIATION_AMY)
+                .withAffiliationHistory(VALID_AFFILIATION_AMY).build();
         assertTrue(ALICE.isSamePerson(editedAlice));
 
         // different name, all other attributes same -> returns false
@@ -87,7 +88,8 @@ public class PersonTest {
         assertFalse(ALICE.equals(editedAlice));
 
         // different tags -> returns false
-        editedAlice = new PersonBuilder(ALICE).withAffiliations(VALID_AFFILIATION_AMY).build();
+        editedAlice = new PersonBuilder(ALICE).withAffiliations(VALID_AFFILIATION_AMY)
+        .withAffiliationHistory(VALID_AFFILIATION_AMY).build();
         assertFalse(ALICE.equals(editedAlice));
     }
 
@@ -95,7 +97,7 @@ public class PersonTest {
     public void toStringMethod() {
         String expected = Person.class.getCanonicalName() + "{name=" + ALICE.getName() + ", phone=" + ALICE.getPhone()
                 + ", email=" + ALICE.getEmail() + ", role=" + ALICE.getRole() + ", affiliations="
-                + ALICE.getAffiliations() + "}";
+                + ALICE.getAffiliations() + ", affiliationHistory=" + ALICE.getAffiliationHistory() + "}";
         assertEquals(expected, ALICE.toString());
     }
 }

--- a/src/test/java/seedu/address/model/person/UniquePersonListTest.java
+++ b/src/test/java/seedu/address/model/person/UniquePersonListTest.java
@@ -44,6 +44,7 @@ public class UniquePersonListTest {
         uniquePersonList.add(ALICE);
         Person editedAlice = new PersonBuilder(ALICE).withRole(VALID_ROLE_BOB)
                 .withAffiliations(VALID_AFFILIATION_AMY)
+                .withAffiliationHistory(VALID_AFFILIATION_AMY)
                 .build();
         assertTrue(uniquePersonList.contains(editedAlice));
     }
@@ -88,6 +89,7 @@ public class UniquePersonListTest {
         uniquePersonList.add(ALICE);
         Person editedAlice = new PersonBuilder(ALICE).withRole(VALID_ROLE_BOB)
                 .withAffiliations(VALID_AFFILIATION_AMY)
+                .withAffiliationHistory(VALID_AFFILIATION_AMY)
                 .build();
         uniquePersonList.setPerson(ALICE, editedAlice);
         UniquePersonList expectedUniquePersonList = new UniquePersonList();

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -45,7 +45,8 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ROLE, VALID_AFFILIATIONS, VALID_AFFILIATION_HISTORY);
+                new JsonAdaptedPerson(INVALID_NAME, VALID_PHONE, VALID_EMAIL,
+                    VALID_ROLE, VALID_AFFILIATIONS, VALID_AFFILIATION_HISTORY);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -61,7 +62,8 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ROLE, VALID_AFFILIATIONS, VALID_AFFILIATION_HISTORY);
+                new JsonAdaptedPerson(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ROLE,
+                    VALID_AFFILIATIONS, VALID_AFFILIATION_HISTORY);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -77,7 +79,8 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ROLE, VALID_AFFILIATIONS, VALID_AFFILIATION_HISTORY);
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ROLE,
+                    VALID_AFFILIATIONS, VALID_AFFILIATION_HISTORY);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -93,7 +96,8 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidRole_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ROLE, VALID_AFFILIATIONS, VALID_AFFILIATION_HISTORY);
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ROLE,
+                    VALID_AFFILIATIONS, VALID_AFFILIATION_HISTORY);
         String expectedMessage = Role.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -111,7 +115,8 @@ public class JsonAdaptedPersonTest {
         List<JsonAdaptedAffiliation> invalidAffiliations = new ArrayList<>(VALID_AFFILIATIONS);
         invalidAffiliations.add(new JsonAdaptedAffiliation(INVALID_AFFILIATION));
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ROLE, invalidAffiliations, VALID_AFFILIATION_HISTORY);
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ROLE,
+                    invalidAffiliations, VALID_AFFILIATION_HISTORY);
         assertThrows(IllegalValueException.class, person::toModelType);
     }
 

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -31,6 +31,10 @@ public class JsonAdaptedPersonTest {
     private static final List<JsonAdaptedAffiliation> VALID_AFFILIATIONS = BENSON.getAffiliations().stream()
             .map(JsonAdaptedAffiliation::new)
             .collect(Collectors.toList());
+    private static final List<JsonAdaptedAffiliation> VALID_AFFILIATION_HISTORY = BENSON.getAffiliationHistory()
+            .stream()
+            .map(JsonAdaptedAffiliation::new)
+            .collect(Collectors.toList());
 
     @Test
     public void toModelType_validPersonDetails_returnsPerson() throws Exception {
@@ -41,7 +45,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ROLE, VALID_AFFILIATIONS);
+                new JsonAdaptedPerson(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ROLE, VALID_AFFILIATIONS, VALID_AFFILIATION_HISTORY);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -49,7 +53,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(null, VALID_PHONE,
-                VALID_EMAIL, VALID_ROLE, VALID_AFFILIATIONS);
+                VALID_EMAIL, VALID_ROLE, VALID_AFFILIATIONS, VALID_AFFILIATION_HISTORY);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -57,7 +61,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ROLE, VALID_AFFILIATIONS);
+                new JsonAdaptedPerson(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ROLE, VALID_AFFILIATIONS, VALID_AFFILIATION_HISTORY);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -65,7 +69,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, null,
-                VALID_EMAIL, VALID_ROLE, VALID_AFFILIATIONS);
+                VALID_EMAIL, VALID_ROLE, VALID_AFFILIATIONS, VALID_AFFILIATION_HISTORY);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -73,7 +77,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ROLE, VALID_AFFILIATIONS);
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ROLE, VALID_AFFILIATIONS, VALID_AFFILIATION_HISTORY);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -81,7 +85,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME,
-                VALID_PHONE, null, VALID_ROLE, VALID_AFFILIATIONS);
+                VALID_PHONE, null, VALID_ROLE, VALID_AFFILIATIONS, VALID_AFFILIATION_HISTORY);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -89,7 +93,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidRole_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ROLE, VALID_AFFILIATIONS);
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ROLE, VALID_AFFILIATIONS, VALID_AFFILIATION_HISTORY);
         String expectedMessage = Role.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -97,7 +101,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullRole_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE,
-                VALID_EMAIL, null, VALID_AFFILIATIONS);
+                VALID_EMAIL, null, VALID_AFFILIATIONS, VALID_AFFILIATION_HISTORY);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Role.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -107,7 +111,7 @@ public class JsonAdaptedPersonTest {
         List<JsonAdaptedAffiliation> invalidAffiliations = new ArrayList<>(VALID_AFFILIATIONS);
         invalidAffiliations.add(new JsonAdaptedAffiliation(INVALID_AFFILIATION));
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ROLE, invalidAffiliations);
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ROLE, invalidAffiliations, VALID_AFFILIATION_HISTORY);
         assertThrows(IllegalValueException.class, person::toModelType);
     }
 

--- a/src/test/java/seedu/address/testutil/DoctorBuilder.java
+++ b/src/test/java/seedu/address/testutil/DoctorBuilder.java
@@ -23,6 +23,7 @@ public class DoctorBuilder {
     private Phone phone;
     private Email email;
     private Set<Affiliation> affiliations;
+    private Set<Affiliation> affiliationHistory;
 
     /**
      * Creates a {@code DoctorBuilder} with the default details.
@@ -32,6 +33,7 @@ public class DoctorBuilder {
         phone = new Phone(DEFAULT_PHONE);
         email = new Email(DEFAULT_EMAIL);
         affiliations = new HashSet<>();
+        affiliationHistory = new HashSet<>();
     }
 
     /**
@@ -42,6 +44,7 @@ public class DoctorBuilder {
         phone = doctorToCopy.getPhone();
         email = doctorToCopy.getEmail();
         affiliations = new HashSet<>(doctorToCopy.getAffiliations());
+        affiliationHistory = new HashSet<>(doctorToCopy.getAffiliationHistory());
     }
 
     /**
@@ -62,6 +65,15 @@ public class DoctorBuilder {
     }
 
     /**
+     * Parses the {@code affiliationHistory} into a {@code Set<Affiliation>} and set it to the {@code Doctor} that
+     * we are building.
+     */
+    public DoctorBuilder withAffiliationHistory(String ... affiliationHistory) {
+        this.affiliationHistory = SampleDataUtil.getAffiliationSet(affiliationHistory);
+        return this;
+    }
+
+    /**
      * Sets the {@code Phone} of the {@code Doctor} that we are building.
      */
     public DoctorBuilder withPhone(String phone) {
@@ -78,7 +90,7 @@ public class DoctorBuilder {
     }
 
     public Doctor build() {
-        return new Doctor(name, phone, email, affiliations);
+        return new Doctor(name, phone, email, affiliations, affiliationHistory);
     }
 
 }

--- a/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
@@ -83,8 +83,9 @@ public class EditPersonDescriptorBuilder {
     }
 
     /**
-     * Parses the {@code affiliationHistory} into a {@code Set<Affiliation>} and set it to the {@code EditPersonDescriptor}
-     * @return
+     * Parses the {@code affiliationHistory} into a {@code Set<Affiliation>} and
+     * set it to the {@code EditPersonDescriptor}
+     * @return EditPersonDescriptorBuilder
      */
     public EditPersonDescriptorBuilder withAffiliationHistory(String... tags) {
         Set<Affiliation> affiliationSet = Stream.of(tags).map(Affiliation::new).collect(Collectors.toSet());

--- a/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
@@ -86,7 +86,7 @@ public class EditPersonDescriptorBuilder {
     /**
      * Parses the {@code affiliationHistory} into a {@code Set<Affiliation>} and
      * set it to the {@code EditPersonDescriptor}
-     * @param affiliations The affiliation history to set.
+     * @param affiliationHistory The affiliation history to set.
      * @return EditPersonDescriptorBuilder
      */
     public EditPersonDescriptorBuilder withAffiliationHistory(String... affiliationHistory) {

--- a/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
@@ -89,8 +89,8 @@ public class EditPersonDescriptorBuilder {
      * @param affiliations The affiliation history to set.
      * @return EditPersonDescriptorBuilder
      */
-    public EditPersonDescriptorBuilder withAffiliationHistory(String... affiliations) {
-        Set<Affiliation> affiliationSet = Stream.of(affiliations).map(Affiliation::new).collect(Collectors.toSet());
+    public EditPersonDescriptorBuilder withAffiliationHistory(String... affiliationHistory) {
+        Set<Affiliation> affiliationSet = Stream.of(affiliationHistory).map(Affiliation::new).collect(Collectors.toSet());
         descriptor.setAffiliationHistory(affiliationSet);
         return this;
     }

--- a/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
@@ -90,7 +90,8 @@ public class EditPersonDescriptorBuilder {
      * @return EditPersonDescriptorBuilder
      */
     public EditPersonDescriptorBuilder withAffiliationHistory(String... affiliationHistory) {
-        Set<Affiliation> affiliationSet = Stream.of(affiliationHistory).map(Affiliation::new).collect(Collectors.toSet());
+        Set<Affiliation> affiliationSet = Stream.of(affiliationHistory)
+            .map(Affiliation::new).collect(Collectors.toSet());
         descriptor.setAffiliationHistory(affiliationSet);
         return this;
     }

--- a/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
@@ -75,9 +75,10 @@ public class EditPersonDescriptorBuilder {
     /**
      * Parses the {@code tags} into a {@code Set<Affiliation>} and set it to the {@code EditPersonDescriptor}
      * that we are building.
+     * @param affiliations The affiliations to set.
      */
-    public EditPersonDescriptorBuilder withAffiliations(String... tags) {
-        Set<Affiliation> affiliationSet = Stream.of(tags).map(Affiliation::new).collect(Collectors.toSet());
+    public EditPersonDescriptorBuilder withAffiliations(String... affiliations) {
+        Set<Affiliation> affiliationSet = Stream.of(affiliations).map(Affiliation::new).collect(Collectors.toSet());
         descriptor.setAffiliations(affiliationSet);
         return this;
     }
@@ -85,10 +86,11 @@ public class EditPersonDescriptorBuilder {
     /**
      * Parses the {@code affiliationHistory} into a {@code Set<Affiliation>} and
      * set it to the {@code EditPersonDescriptor}
+     * @param affiliations The affiliation history to set.
      * @return EditPersonDescriptorBuilder
      */
-    public EditPersonDescriptorBuilder withAffiliationHistory(String... tags) {
-        Set<Affiliation> affiliationSet = Stream.of(tags).map(Affiliation::new).collect(Collectors.toSet());
+    public EditPersonDescriptorBuilder withAffiliationHistory(String... affiliations) {
+        Set<Affiliation> affiliationSet = Stream.of(affiliations).map(Affiliation::new).collect(Collectors.toSet());
         descriptor.setAffiliationHistory(affiliationSet);
         return this;
     }

--- a/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
@@ -37,6 +37,7 @@ public class EditPersonDescriptorBuilder {
         descriptor.setEmail(person.getEmail());
         descriptor.setRole(person.getRole());
         descriptor.setAffiliations(person.getAffiliations());
+        descriptor.setAffiliationHistory(person.getAffiliationHistory());
     }
 
     /**
@@ -78,6 +79,16 @@ public class EditPersonDescriptorBuilder {
     public EditPersonDescriptorBuilder withAffiliations(String... tags) {
         Set<Affiliation> affiliationSet = Stream.of(tags).map(Affiliation::new).collect(Collectors.toSet());
         descriptor.setAffiliations(affiliationSet);
+        return this;
+    }
+
+    /**
+     * Parses the {@code affiliationHistory} into a {@code Set<Affiliation>} and set it to the {@code EditPersonDescriptor}
+     * @return
+     */
+    public EditPersonDescriptorBuilder withAffiliationHistory(String... tags) {
+        Set<Affiliation> affiliationSet = Stream.of(tags).map(Affiliation::new).collect(Collectors.toSet());
+        descriptor.setAffiliationHistory(affiliationSet);
         return this;
     }
 

--- a/src/test/java/seedu/address/testutil/PatientBuilder.java
+++ b/src/test/java/seedu/address/testutil/PatientBuilder.java
@@ -23,6 +23,7 @@ public class PatientBuilder {
     private Phone phone;
     private Email email;
     private Set<Affiliation> affiliations;
+    private Set<Affiliation> affiliationHistory;
 
     /**
      * Creates a {@code PatientBuilder} with the default details.
@@ -32,6 +33,7 @@ public class PatientBuilder {
         phone = new Phone(DEFAULT_PHONE);
         email = new Email(DEFAULT_EMAIL);
         affiliations = new HashSet<>();
+        affiliationHistory = new HashSet<>();
     }
 
     /**
@@ -42,6 +44,7 @@ public class PatientBuilder {
         phone = doctorToCopy.getPhone();
         email = doctorToCopy.getEmail();
         affiliations = new HashSet<>(doctorToCopy.getAffiliations());
+        affiliationHistory = new HashSet<>(doctorToCopy.getAffiliationHistory());
     }
 
     /**
@@ -62,6 +65,15 @@ public class PatientBuilder {
     }
 
     /**
+     * Parses the {@code affiliationHistory} into a {@code Set<Affiliation>} and set it to the {@code Patient} that
+     * we are building.
+     */
+    public PatientBuilder withAffiliationHistory(String ... affiliationHistory) {
+        this.affiliationHistory = SampleDataUtil.getAffiliationSet(affiliationHistory);
+        return this;
+    }
+
+    /**
      * Sets the {@code Phone} of the {@code Patient} that we are building.
      */
     public PatientBuilder withPhone(String phone) {
@@ -78,7 +90,7 @@ public class PatientBuilder {
     }
 
     public Patient build() {
-        return new Patient(name, phone, email, affiliations);
+        return new Patient(name, phone, email, affiliations, affiliationHistory);
     }
 
 }

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -26,6 +26,7 @@ public class PersonBuilder {
     private Email email;
     private Role role;
     private Set<Affiliation> affiliations;
+    private Set<Affiliation> affiliationHistory;
 
     /**
      * Creates a {@code PersonBuilder} with the default details.
@@ -36,6 +37,7 @@ public class PersonBuilder {
         email = new Email(DEFAULT_EMAIL);
         role = new Role(DEFAULT_ROLE);
         affiliations = new HashSet<>();
+        affiliationHistory = new HashSet<>();
     }
 
     /**
@@ -47,6 +49,7 @@ public class PersonBuilder {
         email = personToCopy.getEmail();
         role = personToCopy.getRole();
         affiliations = new HashSet<>(personToCopy.getAffiliations());
+        affiliationHistory = new HashSet<>(personToCopy.getAffiliationHistory());
     }
 
     /**
@@ -63,6 +66,15 @@ public class PersonBuilder {
      */
     public PersonBuilder withAffiliations(String... tags) {
         this.affiliations = SampleDataUtil.getAffiliationSet(tags);
+        return this;
+    }
+
+    /**
+     * Parses the {@code affiliationHistory} into a {@code Set<Affiliation>} and
+     * set it to the {@code Person} that we are building.
+     */
+    public PersonBuilder withAffiliationHistory(String... tags) {
+        this.affiliationHistory = SampleDataUtil.getAffiliationSet(tags);
         return this;
     }
 
@@ -91,7 +103,7 @@ public class PersonBuilder {
     }
 
     public Person build() {
-        return new Person(name, phone, email, role, affiliations);
+        return new Person(name, phone, email, role, affiliations, affiliationHistory);
     }
 
 }

--- a/src/test/java/seedu/address/testutil/TypicalDoctors.java
+++ b/src/test/java/seedu/address/testutil/TypicalDoctors.java
@@ -25,10 +25,12 @@ public class TypicalDoctors {
     public static final Doctor ALICE = new DoctorBuilder().withName("Alice Pauline")
             .withEmail("alice@example.com")
             .withPhone("94351253")
-            .withAffiliations("Benson Meier").build();
+            .withAffiliations("Benson Meier")
+            .withAffiliationHistory("Benson Meier").build();
     public static final Doctor BENSON = new DoctorBuilder().withName("Benson Meier")
             .withEmail("johnd@example.com").withPhone("98765432")
-            .withAffiliations("Alice Pauline", "Carl Kurz").build();
+            .withAffiliations("Alice Pauline", "Carl Kurz")
+            .withAffiliationHistory("Alice Pauline", "Carl Kurz").build();
     public static final Doctor CARL = new DoctorBuilder().withName("Carl Kurz").withPhone("95352563")
             .withEmail("heinz@example.com").build();
     public static final Doctor DANIEL = new DoctorBuilder().withName("Daniel Meier").withPhone("87652533")
@@ -48,10 +50,12 @@ public class TypicalDoctors {
 
     // Manually added - Doctor's details found in {@code CommandTestUtil}
     public static final Doctor AMY = new DoctorBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY)
-            .withEmail(VALID_EMAIL_AMY).withAffiliations(VALID_AFFILIATION_BOB).build();
+            .withEmail(VALID_EMAIL_AMY).withAffiliations(VALID_AFFILIATION_BOB)
+            .withAffiliationHistory(VALID_AFFILIATION_BOB).build();
     public static final Doctor BOB = new DoctorBuilder().withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
             .withEmail(VALID_EMAIL_BOB)
             .withAffiliations(VALID_AFFILIATION_AMY, VALID_AFFILIATION_BOB)
+            .withAffiliationHistory(VALID_AFFILIATION_AMY, VALID_AFFILIATION_BOB)
             .build();
 
     public static final String KEYWORD_MATCHING_MEIER = "Meier"; // A keyword that matches MEIER

--- a/src/test/java/seedu/address/testutil/TypicalPatients.java
+++ b/src/test/java/seedu/address/testutil/TypicalPatients.java
@@ -24,10 +24,12 @@ public class TypicalPatients {
     public static final Patient ALICE = new PatientBuilder().withName("Alice Pauline")
             .withEmail("alice@example.com")
             .withPhone("94351253")
-            .withAffiliations("Benson Meier").build();
+            .withAffiliations("Benson Meier")
+            .withAffiliationHistory("Benson Meier").build();
     public static final Patient BENSON = new PatientBuilder().withName("Benson Meier")
             .withEmail("johnd@example.com").withPhone("98765432")
-            .withAffiliations("Alice Pauline", "Carl Kurz").build();
+            .withAffiliations("Alice Pauline", "Carl Kurz")
+            .withAffiliationHistory("Alice Pauline", "Carl Kurz").build();
     public static final Patient CARL = new PatientBuilder().withName("Carl Kurz").withPhone("95352563")
             .withEmail("heinz@example.com").build();
     public static final Patient DANIEL = new PatientBuilder().withName("Daniel Meier").withPhone("87652533")
@@ -47,10 +49,12 @@ public class TypicalPatients {
 
     // Manually added - Patient's details found in {@code CommandTestUtil}
     public static final Patient AMY = new PatientBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY)
-            .withEmail(VALID_EMAIL_AMY).withAffiliations(VALID_AFFILIATION_BOB).build();
+            .withEmail(VALID_EMAIL_AMY).withAffiliations(VALID_AFFILIATION_BOB)
+            .withAffiliationHistory(VALID_AFFILIATION_BOB).build();
     public static final Patient BOB = new PatientBuilder().withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
             .withEmail(VALID_EMAIL_BOB)
             .withAffiliations(VALID_AFFILIATION_AMY, VALID_AFFILIATION_BOB)
+            .withAffiliationHistory(VALID_AFFILIATION_AMY, VALID_AFFILIATION_BOB)
             .build();
 
     public static final String KEYWORD_MATCHING_MEIER = "Meier"; // A keyword that matches MEIER

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -26,11 +26,13 @@ public class TypicalPersons {
     public static final Person ALICE = new PersonBuilder().withName("Alice Pauline")
             .withRole("Doctor").withEmail("alice@example.com")
             .withPhone("94351253")
-            .withAffiliations("Benson Meier").build();
+            .withAffiliations("Benson Meier")
+            .withAffiliationHistory("Benson Meier").build();
     public static final Person BENSON = new PersonBuilder().withName("Benson Meier")
             .withRole("Patient")
             .withEmail("johnd@example.com").withPhone("98765432")
-            .withAffiliations("Alice Pauline", "Carl Kurz").build();
+            .withAffiliations("Alice Pauline", "Carl Kurz")
+            .withAffiliationHistory("Alice Pauline", "Carl Kurz").build();
     public static final Person CARL = new PersonBuilder().withName("Carl Kurz").withPhone("95352563")
             .withEmail("heinz@example.com").withRole("Doctor").build();
     public static final Person DANIEL = new PersonBuilder().withName("Daniel Meier").withPhone("87652533")
@@ -76,11 +78,13 @@ public class TypicalPersons {
         Person alice = new PersonBuilder().withName("Alice Pauline")
                 .withRole("Doctor").withEmail("alice@example.com")
                 .withPhone("94351253")
-                .withAffiliations("Benson Meier").build();
+                .withAffiliations("Benson Meier")
+                .withAffiliationHistory("Benson Meier").build();
         Person benson = new PersonBuilder().withName("Benson Meier")
                 .withRole("Patient")
                 .withEmail("johnd@example.com").withPhone("98765432")
-                .withAffiliations("Alice Pauline", "Carl Kurz").build();
+                .withAffiliations("Alice Pauline", "Carl Kurz")
+                .withAffiliationHistory("Alice Pauline", "Carl Kurz").build();
         Person carl = new PersonBuilder().withName("Carl Kurz").withPhone("95352563")
                 .withEmail("heinz@example.com").withRole("Doctor").build();
         Person daniel = new PersonBuilder().withName("Daniel Meier").withPhone("87652533")


### PR DESCRIPTION
Add affiliationHistory feature to Person class

Main changes:
- AffiliationHistory as an attribute in Person (if not specified, it'll use affiliations as history)
- Update addCommand to add to history when affiliation is stated
- Update EditCommand to add to history when affiliation is changed
- Test cases to include withAffiliationHistory
- Misc like adding commas to affiliations in PersonCard

For discussion:
- make Person abstract class
- replace Person in testing
- editing affiliations and affiliationHistory
- **Make changing roles illegal (to preserve affiliation type constraint)**

Future updates/for discussion:
- update affiliationHistory when name changes
