### PR TITLE
Add shift days attribute for Doctor class 

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,5 @@
   * It is **written in OOP fashion**. It provides a **reasonably well-written** code base (around 6 KLoC).
   * It has a **reasonable level of user and developer documentation**.
 * It is named `MediSync` as it allows the syncing of directory information in a medical context.
-* For the detailed documentation of this project, see the **[MediSync Product Website]()**.
+* For the detailed documentation of this project, see the **[MediSync Product Website](https://ay2324s1-cs2103-t16-2.github.io/tp/)**.
 * This project is based on the AddressBook-Level3 project created by the [SE-EDU initiative](https://se-education.org).

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -7,6 +7,7 @@ import java.util.stream.Stream;
 
 import seedu.address.logic.parser.Prefix;
 import seedu.address.model.affiliation.Affiliation;
+import seedu.address.model.person.Doctor;
 import seedu.address.model.person.Person;
 
 /**
@@ -65,6 +66,11 @@ public class Messages {
             }
         }
         builder.append("}");
+
+        if (person instanceof Doctor) {
+            builder.append("; Shift Days: ");
+            builder.append(((Doctor) person).getShiftDays());
+        }
         return builder.toString();
     }
 

--- a/src/main/java/seedu/address/model/person/Doctor.java
+++ b/src/main/java/seedu/address/model/person/Doctor.java
@@ -1,5 +1,6 @@
 package seedu.address.model.person;
 
+import java.util.Objects;
 import java.util.Set;
 
 import seedu.address.model.affiliation.Affiliation;
@@ -9,12 +10,17 @@ import seedu.address.model.affiliation.Affiliation;
  */
 public class Doctor extends Person {
 
+    private final ShiftDays shiftDays;
+
     /**
      * Every field must be present and not null.
      */
     public Doctor(Name name, Phone phone, Email email,
         Set<Affiliation> affiliations, Set<Affiliation> affiliationHistory) {
         super(name, phone, email, new Role("Doctor"), affiliations, affiliationHistory);
+
+        // Instantiation of Doctor should always begin with empty shift days.
+        shiftDays = new ShiftDays();
     }
 
     /**
@@ -22,11 +28,56 @@ public class Doctor extends Person {
      */
     public Doctor(Name name, Phone phone, Email email, Set<Affiliation> affiliations) {
         super(name, phone, email, new Role("Doctor"), affiliations);
+
+        // Instantiation of Doctor should always begin with empty shift days.
+        shiftDays = new ShiftDays();
+    }
+
+    public ShiftDays getShiftDays() {
+        return shiftDays;
+    }
+
+    public Doctor setShiftDays(ShiftDays shiftDays) {
+        this.shiftDays.modifyShiftDays(shiftDays.getShiftDays());
+        return this;
+    }
+
+    /**
+     * Returns true if both doctors have the same identity and data fields.
+     * This defines a stronger notion of equality between two doctors.
+     */
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof Doctor)) {
+            return false;
+        }
+
+        Doctor otherDoctor = (Doctor) other;
+        return getName().equals(otherDoctor.getName())
+                && getPhone().equals(otherDoctor.getPhone())
+                && getEmail().equals(otherDoctor.getEmail())
+                && getAffiliations().equals(otherDoctor.getAffiliations())
+                && getAffiliationHistory().equals(otherDoctor.getAffiliationHistory())
+                && shiftDays.equals(otherDoctor.getShiftDays());
+    }
+
+    @Override
+    public int hashCode() {
+        // use this method for custom fields hashing instead of implementing your own
+        return Objects.hash(getName(), getPhone(), getEmail(), getRole(), getAffiliations(),
+                getAffiliationHistory(), shiftDays);
     }
 
     @Override
     public String toString() {
-        return getStringBuilderRepresentation().toString();
+        return getStringBuilderRepresentation()
+                .add("shiftDays", shiftDays)
+                .toString();
     }
 
 }

--- a/src/main/java/seedu/address/model/person/ShiftDays.java
+++ b/src/main/java/seedu/address/model/person/ShiftDays.java
@@ -1,0 +1,116 @@
+package seedu.address.model.person;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Represents a set of ShiftDays in the contact list.
+ */
+public class ShiftDays {
+
+    public static final int SMALLEST_DAY_REPRESENTATION = 1;
+    public static final int NUMBER_OF_DAYS_IN_WEEK = 7;
+
+    public static final Map<Integer, String> DAY_OF_WEEK_MAP = new HashMap<>() {{
+            put(1, "Mon");
+            put(2, "Tue");
+            put(3, "Wed");
+            put(4, "Thu");
+            put(5, "Fri");
+            put(6, "Sat");
+            put(7, "Sun");
+        }};
+
+    public static final String MESSAGE_CONSTRAINTS = "Indication of shift days should be integers "
+            + "between 1 to 7 inclusive.";
+
+    public final Set<Integer> shiftDays;
+
+    /**
+     * Constructs a default {@code ShiftDays} with no shifts.
+     */
+    public ShiftDays() {
+        this.shiftDays = new HashSet<>();
+    }
+
+    /**
+     * Constructs a {@code ShiftDays}.
+     *
+     * @param shiftDays A valid set of shift day integers.
+     */
+    public ShiftDays(Set<Integer> shiftDays) {
+        requireNonNull(shiftDays);
+        checkArgument(isValidShiftDays(shiftDays), MESSAGE_CONSTRAINTS);
+        this.shiftDays = shiftDays;
+    }
+
+    /**
+     * Returns true if a given set contains valid shift day integers.
+     */
+    public static boolean isValidShiftDays(Set<Integer> test) {
+        return test
+                .stream()
+                .allMatch(shiftDay -> shiftDay >= SMALLEST_DAY_REPRESENTATION && shiftDay <= NUMBER_OF_DAYS_IN_WEEK);
+    }
+
+    /**
+     * Returns the set of shiftDays.
+     */
+    public Set<Integer> getShiftDays() {
+        return shiftDays;
+    }
+
+    /**
+     * Modifies the set of shift days.
+     *
+     * @param shiftDays The set of integers representing the shift days.
+     */
+    public ShiftDays modifyShiftDays(Set<Integer> shiftDays) {
+        this.shiftDays.clear();
+        this.shiftDays.addAll(shiftDays);
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof ShiftDays)) {
+            return false;
+        }
+
+        ShiftDays otherShiftDays = (ShiftDays) other;
+        return shiftDays.equals(otherShiftDays.shiftDays);
+    }
+
+    @Override
+    public int hashCode() {
+        return shiftDays.hashCode();
+    }
+
+    /**
+     * Format state as text for viewing.
+     */
+    public String toString() {
+        ArrayList<Integer> sortedShiftDays = new ArrayList<>(shiftDays);
+        Collections.sort(sortedShiftDays);
+
+        ArrayList<String> daysOfWeek = new ArrayList<>();
+        for (int shiftDay : sortedShiftDays) {
+            daysOfWeek.add(DAY_OF_WEEK_MAP.get(shiftDay));
+        }
+
+        return "[" + String.join(", ", daysOfWeek) + "]";
+    }
+
+}

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -7,11 +7,12 @@ import java.util.stream.Collectors;
 import seedu.address.model.AddressBook;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.affiliation.Affiliation;
+import seedu.address.model.person.Doctor;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
+import seedu.address.model.person.Patient;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
-import seedu.address.model.person.Role;
 
 /**
  * Contains utility methods for populating {@code AddressBook} with sample data.
@@ -19,24 +20,18 @@ import seedu.address.model.person.Role;
 public class SampleDataUtil {
     public static Person[] getSamplePersons() {
         return new Person[]{
-            new Person(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
-                new Role("Doctor"),
-            getAffiliationSet("Bernice Yu")),
-            new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
-                new Role("Patient"),
-            getAffiliationSet("Alex Yeoh")),
-            new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
-                new Role("Patient"),
-            getAffiliationSet()),
-            new Person(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
-                new Role("Doctor"),
-            getAffiliationSet()),
-            new Person(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
-                new Role("Patient"),
-            getAffiliationSet()),
-            new Person(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
-                new Role("Doctor"),
-            getAffiliationSet())
+            new Doctor(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
+                    getAffiliationSet("Bernice Yu", "Charlotte Oliveiro")),
+            new Patient(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
+                    getAffiliationSet("Alex Yeoh")),
+            new Patient(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
+                    getAffiliationSet("Alex Yeoh")),
+            new Doctor(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
+                    getAffiliationSet("Irfan Ibrahim")),
+            new Patient(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
+                    getAffiliationSet("David Li")),
+            new Doctor(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
+                    getAffiliationSet())
         };
     }
 

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -115,7 +115,7 @@ class JsonAdaptedPerson {
 
         final Set<Affiliation> modelAffiliations = new HashSet<>(personAffiliations);
         final Set<Affiliation> modelAffiliationHistory = new HashSet<>(personAffiliationHistory);
-        return new Person(modelName, modelPhone, modelEmail, modelRole, modelAffiliations, modelAffiliationHistory);
+        return modelRole.generatePerson(modelName, modelPhone, modelEmail, modelAffiliations, modelAffiliationHistory);
     }
 
 }

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -15,8 +15,7 @@ import seedu.address.commons.core.LogsCenter;
  */
 public class HelpWindow extends UiPart<Stage> {
 
-    public static final String USERGUIDE_URL = "https://github.com/AY2324S1-CS2103-T16-2"
-            + "/tp/blob/master/docs/UserGuide.md";
+    public static final String USERGUIDE_URL = "https://ay2324s1-cs2103-t16-2.github.io/tp/UserGuide.html";
     public static final String HELP_MESSAGE = "Refer to the user guide: " + USERGUIDE_URL;
 
     private static final Logger logger = LogsCenter.getLogger(HelpWindow.class);

--- a/src/main/java/seedu/address/ui/InformationWindow.java
+++ b/src/main/java/seedu/address/ui/InformationWindow.java
@@ -7,8 +7,9 @@ import javafx.scene.control.Label;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
 import seedu.address.model.affiliation.Affiliation;
+import seedu.address.model.person.Doctor;
+import seedu.address.model.person.Patient;
 import seedu.address.model.person.Person;
-import seedu.address.model.person.Role;
 
 /**
  * A UI component that displays information of a {@code Person}.
@@ -16,6 +17,8 @@ import seedu.address.model.person.Role;
 public class InformationWindow extends UiPart<Region> {
 
     private static final String FXML = "InformationWindow.fxml";
+
+    private static final int[] SAMPLE_SHIFT_DAYS = {1, 4, 6};
 
     @FXML
     private VBox fullWindow;
@@ -41,6 +44,7 @@ public class InformationWindow extends UiPart<Region> {
     private Label shiftSat;
     @FXML
     private Label shiftSun;
+    private Label[] shiftDays;
 
     @FXML
     private VBox affnBlock;
@@ -54,6 +58,7 @@ public class InformationWindow extends UiPart<Region> {
      */
     public InformationWindow() {
         super(FXML);
+        shiftDays = new Label[]{shiftMon, shiftTue, shiftWed, shiftThu, shiftFri, shiftSat, shiftSun};
 
         // The initialisation should not render the information window.
         resetWindow();
@@ -70,58 +75,54 @@ public class InformationWindow extends UiPart<Region> {
         name.setText(person.getName().fullName);
         role.setText(person.getRole().value);
 
-        if (person.getRole().toString().toUpperCase().equals(Role.Type.DOCTOR.name())) {
-            displayDoctorInformation(person);
-        } else if (person.getRole().toString().toUpperCase().equals(Role.Type.PATIENT.name())) {
-            displayPatientInformation(person);
+        if (person instanceof Doctor) {
+            displayDoctorInformation((Doctor) person);
+        } else if (person instanceof Patient) {
+            displayPatientInformation((Patient) person);
         }
 
         showWindow();
     }
 
     /**
-     * Displays information of the given {@code Person} that has been identified as a {@code Doctor}.
-     * @param person the intended doctor for display.
+     * Displays information of the given {@code Doctor}.
+     * @param doctor the intended doctor for display.
      */
-    private void displayDoctorInformation(Person person) {
+    private void displayDoctorInformation(Doctor doctor) {
         role.setStyle("-fx-background-color: #89CFF0; -fx-font-weight: bold; -fx-text-fill: #0047AB");
-        setShiftDays(person);
-        setAffiliations(person);
+        setShiftDays(doctor);
+        setAffiliations(doctor);
         affnCount.setText("Tending to:");
         affnBlock.setStyle("-fx-border-color: #BBBBBB; -fx-border-width: 2 0 0 0;");
     }
 
     /**
-     * Displays information of the given {@code Person} that has been identified as a {@code Patient}.
-     * @param person the intended patient for display.
+     * Displays information of the given {@code Patient}.
+     * @param patient the intended patient for display.
      */
-    private void displayPatientInformation(Person person) {
+    private void displayPatientInformation(Patient patient) {
         role.setStyle("-fx-background-color: #E97451; -fx-font-weight: bold; -fx-text-fill: #8B4000");
         clearShiftDays();
-        setAffiliations(person);
+        setAffiliations(patient);
         affnCount.setText("Attended by:");
         affnBlock.setStyle("-fx-border-color: #BBBBBB; -fx-border-width: 2 0 0 0;");
     }
 
     /**
-     * Sets the shift days information of the given {@code Person}.
-     * @param person the intended person for display.
+     * Sets the shift days information of the given {@code Doctor}.
+     * @param doctor the intended person for display.
      */
-    private void setShiftDays(Person person) {
+    private void setShiftDays(Doctor doctor) {
 
         shiftBlock.setVisible(true);
         shiftBlock.setManaged(true);
         shiftBlock.setStyle("-fx-border-color: #BBBBBB; -fx-border-width: 2 0 0 0;");
         shiftHeader.setText("Shift days:");
 
-        // Function to be modified in the future. Currently picks only Mon, Thu and Sat.
-        shiftMon.setStyle("-fx-background-color: #AFE1AF; -fx-font-weight: bold; -fx-text-fill: #008000");
-        // shiftTue.setStyle("-fx-background-color: #89CFF0; -fx-font-weight: bold; -fx-text-fill: #0047AB");
-        // shiftWed.setStyle("-fx-background-color: #89CFF0; -fx-font-weight: bold; -fx-text-fill: #0047AB");
-        shiftThu.setStyle("-fx-background-color: #AFE1AF; -fx-font-weight: bold; -fx-text-fill: #008000");
-        // shiftFri.setStyle("-fx-background-color: #89CFF0; -fx-font-weight: bold; -fx-text-fill: #0047AB");
-        shiftSat.setStyle("-fx-background-color: #AFE1AF; -fx-font-weight: bold; -fx-text-fill: #008000");
-        // shiftSun.setStyle("-fx-background-color: #89CFF0; -fx-font-weight: bold; -fx-text-fill: #0047AB");
+        for (int shiftDay : SAMPLE_SHIFT_DAYS) {
+            shiftDays[shiftDay - 1]
+                    .setStyle("-fx-background-color: #AFE1AF; -fx-font-weight: bold; -fx-text-fill: #008000");
+        }
     }
 
     /**
@@ -154,6 +155,9 @@ public class InformationWindow extends UiPart<Region> {
      * Removes the shift days information from the information window.
      */
     private void clearShiftDays() {
+        for (Label shiftDay : shiftDays) {
+            shiftDay.setStyle("-fx-background-color: transparent; -fx-font-weight: normal; -fx-text-fill: black");;
+        }
         shiftBlock.setVisible(false);
         shiftBlock.setManaged(false);
     }

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -6,14 +6,14 @@
     "email" : "alice@example.com",
     "role" : "Doctor",
     "affiliations" : [ "Benson Meier" ],
-    "affiliationHistory" : [ "Benson Meier" ]
+    "affiliationHistory" : [ "Thomas Mink", "Benson Meier" ]
   }, {
     "name" : "Benson Meier",
     "phone" : "98765432",
     "email" : "johnd@example.com",
-    "role" : "Patient",
-    "affiliations" : [ "Alice Pauline", "Carl Kurz" ],
-    "affiliationHistory" : [ "Alice Pauline", "Carl Kurz" ]
+    "role" : "Doctor",
+    "affiliations" : [ ],
+    "affiliationHistory" : [ "Alice Menti", "Bonas Kurz" ]
   }, {
     "name" : "Carl Kurz",
     "phone" : "95352563",
@@ -25,7 +25,7 @@
     "name" : "Daniel Meier",
     "phone" : "87652533",
     "email" : "cornelia@example.com",
-    "role" : "Patient",
+    "role" : "Doctor",
     "affiliations" : [ ],
     "affiliationHistory" : [ ]
   }, {
@@ -39,7 +39,7 @@
     "name" : "Fiona Kunz",
     "phone" : "9482427",
     "email" : "lydia@example.com",
-    "role" : "Patient",
+    "role" : "Doctor",
     "affiliations" : [ ],
     "affiliationHistory" : [ ]
   }, {

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -11,7 +11,9 @@ import static seedu.address.testutil.Assert.assertThrows;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -36,8 +38,9 @@ public class CommandTestUtil {
     public static final String VALID_ROLE_AMY = "Doctor";
     public static final String VALID_ROLE_BOB = "Patient";
     public static final String VALID_AFFILIATION_AMY = "Amy Bee";
-    public static final String VALID_AFFILIATION_DANIEL = "Daniel Meier";
     public static final String VALID_AFFILIATION_BOB = "Bob Choo";
+    public static final Set<Integer> VALID_SHIFTDAYS_AMY = new HashSet<>(Arrays.asList(1, 2, 3, 4, 5));
+
 
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
     public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -5,15 +5,14 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_AFFILIATION_DANIEL;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.address.testutil.TypicalDoctors.getTypicalDoctorsAddressBook;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
-import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
 
@@ -24,20 +23,23 @@ import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Doctor;
+import seedu.address.model.person.Patient;
 import seedu.address.model.person.Person;
+import seedu.address.testutil.DoctorBuilder;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
-import seedu.address.testutil.PersonBuilder;
+import seedu.address.testutil.PatientBuilder;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for EditCommand.
  */
 public class EditCommandTest {
 
-    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private Model model = new ModelManager(getTypicalDoctorsAddressBook(), new UserPrefs());
 
     @Test
     public void execute_allFieldsSpecifiedUnfilteredList_failure() {
-        Person editedPerson = new PersonBuilder().withAffiliationHistory("Benson Meier").build();
+        Patient editedPerson = new PatientBuilder().withAffiliationHistory("Benson Meier").build();
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(editedPerson).build();
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
 
@@ -49,14 +51,11 @@ public class EditCommandTest {
         Index indexLastPerson = Index.fromOneBased(model.getFilteredPersonList().size());
         Person lastPerson = model.getFilteredPersonList().get(indexLastPerson.getZeroBased());
 
-        PersonBuilder personInList = new PersonBuilder(lastPerson);
-        Person editedPerson = personInList.withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
-                .withAffiliations(VALID_AFFILIATION_DANIEL)
-                .withAffiliationHistory(VALID_AFFILIATION_DANIEL).build();
+        DoctorBuilder personInList = new DoctorBuilder((Doctor) lastPerson);
+        Doctor editedPerson = personInList.withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB).build();
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB)
-                .withPhone(VALID_PHONE_BOB).withAffiliations(VALID_AFFILIATION_DANIEL)
-                .withAffiliationHistory(VALID_AFFILIATION_DANIEL).build();
+                .withPhone(VALID_PHONE_BOB).build();
         EditCommand editCommand = new EditCommand(indexLastPerson, descriptor);
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
@@ -82,14 +81,14 @@ public class EditCommandTest {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
 
         Person personInFilteredList = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        Person editedPerson = new PersonBuilder(personInFilteredList).withName(VALID_NAME_BOB).build();
+        Doctor editedDoctor = new DoctorBuilder((Doctor) personInFilteredList).withName(VALID_NAME_BOB).build();
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON,
                 new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build());
 
-        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedDoctor));
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-        expectedModel.setPerson(model.getFilteredPersonList().get(0), editedPerson);
+        expectedModel.setPerson(model.getFilteredPersonList().get(0), editedDoctor);
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
 

--- a/src/test/java/seedu/address/model/person/DoctorTest.java
+++ b/src/test/java/seedu/address/model/person/DoctorTest.java
@@ -7,6 +7,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_AFFILIATION_AMY
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_SHIFTDAYS_AMY;
 import static seedu.address.testutil.TypicalDoctors.ALICE;
 import static seedu.address.testutil.TypicalDoctors.BOB;
 
@@ -86,13 +87,18 @@ public class DoctorTest {
         editedAlice = new DoctorBuilder(ALICE).withAffiliations(VALID_AFFILIATION_AMY)
         .withAffiliationHistory(VALID_AFFILIATION_AMY).build();
         assertFalse(ALICE.equals(editedAlice));
+
+        // different shift days -> return false
+        editedAlice = new DoctorBuilder(ALICE).withShiftDays(VALID_SHIFTDAYS_AMY).build();
+        assertFalse(ALICE.equals(editedAlice));
     }
 
     @Test
     public void toStringMethod() {
         String expected = Doctor.class.getCanonicalName() + "{name=" + ALICE.getName() + ", phone=" + ALICE.getPhone()
                 + ", email=" + ALICE.getEmail() + ", role=" + ALICE.getRole() + ", affiliations="
-                + ALICE.getAffiliations() + ", affiliationHistory=" + ALICE.getAffiliationHistory() + "}";
+                + ALICE.getAffiliations() + ", affiliationHistory=" + ALICE.getAffiliationHistory()
+                + ", shiftDays=" + ALICE.getShiftDays() + "}";
         assertEquals(expected, ALICE.toString());
     }
 }

--- a/src/test/java/seedu/address/model/person/ShiftDaysTest.java
+++ b/src/test/java/seedu/address/model/person/ShiftDaysTest.java
@@ -1,0 +1,72 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+public class ShiftDaysTest {
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new ShiftDays(null));
+    }
+
+    @Test
+    public void constructor_invalidShiftDays_throwsIllegalArgumentException() {
+        Set<Integer> invalidShiftDays = new HashSet<>();
+        invalidShiftDays.add(9);
+        assertThrows(IllegalArgumentException.class, () -> new ShiftDays(invalidShiftDays));
+    }
+
+    @Test
+    public void isValidShiftDays() {
+
+        // null shift days set
+        assertThrows(NullPointerException.class, () -> ShiftDays.isValidShiftDays(null));
+
+        Set<Integer> invalidShiftDays = new HashSet<>();
+        // invalid shift days
+        invalidShiftDays.add(12);
+        assertFalse(ShiftDays.isValidShiftDays(invalidShiftDays)); // number larger than 7
+        invalidShiftDays.remove(12);
+        invalidShiftDays.add(0);
+        assertFalse(ShiftDays.isValidShiftDays(invalidShiftDays)); // number smaller than 1
+        invalidShiftDays.add(15);
+        assertFalse(ShiftDays.isValidShiftDays(invalidShiftDays)); // both number smaller than 1 and larger than 7
+
+        Set<Integer> validShiftDays = new HashSet<>();
+        // valid shift days
+        assertTrue(ShiftDays.isValidShiftDays(validShiftDays)); // Empty Shift Days
+        validShiftDays.add(6);
+        assertTrue(ShiftDays.isValidShiftDays(validShiftDays)); // Saturday(6)
+        validShiftDays.add(2);
+        assertTrue(ShiftDays.isValidShiftDays(validShiftDays)); // Tuesday(2) and Saturday(6)
+    }
+
+    @Test
+    public void equals() {
+        ShiftDays shiftDays = new ShiftDays(new HashSet<>());
+
+        // same values -> returns true
+        assertTrue(shiftDays.equals(new ShiftDays(new HashSet<>())));
+
+        // same object -> returns true
+        assertTrue(shiftDays.equals(shiftDays));
+
+        // null -> returns false
+        assertFalse(shiftDays.equals(null));
+
+        // different types -> returns false
+        assertFalse(shiftDays.equals(5.0f));
+
+        // different values -> returns false
+        Set<Integer> otherShiftDaysSet = new HashSet<>();
+        otherShiftDaysSet.add(5);
+        assertFalse(shiftDays.equals(new ShiftDays(otherShiftDaysSet)));
+    }
+}

--- a/src/test/java/seedu/address/model/person/ShiftDaysTest.java
+++ b/src/test/java/seedu/address/model/person/ShiftDaysTest.java
@@ -1,9 +1,11 @@
 package seedu.address.model.person;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -68,5 +70,10 @@ public class ShiftDaysTest {
         Set<Integer> otherShiftDaysSet = new HashSet<>();
         otherShiftDaysSet.add(5);
         assertFalse(shiftDays.equals(new ShiftDays(otherShiftDaysSet)));
+    }
+
+    @Test
+    public void toString_compareAdjustedShiftDays_success() {
+        assertEquals("[Mon, Tue]", new ShiftDays(new HashSet<>(Arrays.asList(1, 2))).toString());
     }
 }

--- a/src/test/java/seedu/address/model/util/SampleDataUtilTest.java
+++ b/src/test/java/seedu/address/model/util/SampleDataUtilTest.java
@@ -1,0 +1,26 @@
+package seedu.address.model.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import seedu.address.model.person.Email;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Phone;
+
+import org.junit.jupiter.api.Test;
+
+public class SampleDataUtilTest {
+
+    @Test
+    public void retrieveData_compareAttributes_success() {
+        Person[] samplePersons = SampleDataUtil.getSamplePersons();
+
+        assertEquals(new Name("Alex Yeoh"), samplePersons[0].getName());
+        assertEquals(new Name("Bernice Yu"), samplePersons[1].getName());
+        assertEquals(new Phone("93210283"), samplePersons[2].getPhone());
+        assertEquals(new Email("lidavid@example.com"), samplePersons[3].getEmail());
+        assertEquals(new Name("Irfan Ibrahim"), samplePersons[4].getName());
+        assertEquals(new Phone("92624417"), samplePersons[5].getPhone());
+
+    }
+}

--- a/src/test/java/seedu/address/model/util/SampleDataUtilTest.java
+++ b/src/test/java/seedu/address/model/util/SampleDataUtilTest.java
@@ -2,12 +2,12 @@ package seedu.address.model.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import org.junit.jupiter.api.Test;
+
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
-
-import org.junit.jupiter.api.Test;
 
 public class SampleDataUtilTest {
 

--- a/src/test/java/seedu/address/storage/JsonSerializableAddressBookTest.java
+++ b/src/test/java/seedu/address/storage/JsonSerializableAddressBookTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.commons.util.JsonUtil;
 import seedu.address.model.AddressBook;
-import seedu.address.testutil.TypicalPersons;
+import seedu.address.testutil.TypicalDoctors;
 
 public class JsonSerializableAddressBookTest {
 
@@ -25,7 +25,7 @@ public class JsonSerializableAddressBookTest {
         JsonSerializableAddressBook dataFromFile = JsonUtil.readJsonFile(TYPICAL_PERSONS_FILE,
                 JsonSerializableAddressBook.class).get();
         AddressBook addressBookFromFile = dataFromFile.toModelType();
-        AddressBook typicalPersonsAddressBook = TypicalPersons.getTypicalAddressBook();
+        AddressBook typicalPersonsAddressBook = TypicalDoctors.getTypicalDoctorsAddressBook();
         assertEquals(addressBookFromFile, typicalPersonsAddressBook);
     }
 

--- a/src/test/java/seedu/address/testutil/DoctorBuilder.java
+++ b/src/test/java/seedu/address/testutil/DoctorBuilder.java
@@ -8,6 +8,7 @@ import seedu.address.model.person.Doctor;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
+import seedu.address.model.person.ShiftDays;
 import seedu.address.model.util.SampleDataUtil;
 
 /**
@@ -24,6 +25,7 @@ public class DoctorBuilder {
     private Email email;
     private Set<Affiliation> affiliations;
     private Set<Affiliation> affiliationHistory;
+    private ShiftDays shiftDays;
 
     /**
      * Creates a {@code DoctorBuilder} with the default details.
@@ -34,6 +36,7 @@ public class DoctorBuilder {
         email = new Email(DEFAULT_EMAIL);
         affiliations = new HashSet<>();
         affiliationHistory = new HashSet<>();
+        shiftDays = new ShiftDays();
     }
 
     /**
@@ -45,6 +48,7 @@ public class DoctorBuilder {
         email = doctorToCopy.getEmail();
         affiliations = new HashSet<>(doctorToCopy.getAffiliations());
         affiliationHistory = new HashSet<>(doctorToCopy.getAffiliationHistory());
+        shiftDays = doctorToCopy.getShiftDays();
     }
 
     /**
@@ -89,8 +93,15 @@ public class DoctorBuilder {
         return this;
     }
 
-    public Doctor build() {
-        return new Doctor(name, phone, email, affiliations, affiliationHistory);
+    /**
+     * Sets the {@code ShiftDays} of the {@code Doctor} that we are building.
+     */
+    public DoctorBuilder withShiftDays(Set<Integer> shiftDays) {
+        this.shiftDays = new ShiftDays(shiftDays);
+        return this;
     }
 
+    public Doctor build() {
+        return new Doctor(name, phone, email, affiliations, affiliationHistory).setShiftDays(shiftDays);
+    }
 }

--- a/src/test/java/seedu/address/testutil/TypicalDoctors.java
+++ b/src/test/java/seedu/address/testutil/TypicalDoctors.java
@@ -26,11 +26,10 @@ public class TypicalDoctors {
             .withEmail("alice@example.com")
             .withPhone("94351253")
             .withAffiliations("Benson Meier")
-            .withAffiliationHistory("Benson Meier").build();
+            .withAffiliationHistory("Thomas Mink", "Benson Meier").build();
     public static final Doctor BENSON = new DoctorBuilder().withName("Benson Meier")
             .withEmail("johnd@example.com").withPhone("98765432")
-            .withAffiliations("Alice Pauline", "Carl Kurz")
-            .withAffiliationHistory("Alice Pauline", "Carl Kurz").build();
+            .withAffiliationHistory("Alice Menti", "Bonas Kurz").build();
     public static final Doctor CARL = new DoctorBuilder().withName("Carl Kurz").withPhone("95352563")
             .withEmail("heinz@example.com").build();
     public static final Doctor DANIEL = new DoctorBuilder().withName("Daniel Meier").withPhone("87652533")
@@ -65,7 +64,7 @@ public class TypicalDoctors {
     /**
      * Returns an {@code AddressBook} with all the typical doctors.
      */
-    public static AddressBook getTypicalAddressBook() {
+    public static AddressBook getTypicalDoctorsAddressBook() {
         AddressBook ab = new AddressBook();
         for (Doctor doctor : getTypicalDoctors()) {
             ab.addPerson(doctor);

--- a/src/test/java/seedu/address/testutil/TypicalPatients.java
+++ b/src/test/java/seedu/address/testutil/TypicalPatients.java
@@ -24,12 +24,10 @@ public class TypicalPatients {
     public static final Patient ALICE = new PatientBuilder().withName("Alice Pauline")
             .withEmail("alice@example.com")
             .withPhone("94351253")
-            .withAffiliations("Benson Meier")
-            .withAffiliationHistory("Benson Meier").build();
+            .withAffiliationHistory("Thomas Mink").build();
     public static final Patient BENSON = new PatientBuilder().withName("Benson Meier")
             .withEmail("johnd@example.com").withPhone("98765432")
-            .withAffiliations("Alice Pauline", "Carl Kurz")
-            .withAffiliationHistory("Alice Pauline", "Carl Kurz").build();
+            .withAffiliationHistory("Alice Menti", "Bonas Kurz").build();
     public static final Patient CARL = new PatientBuilder().withName("Carl Kurz").withPhone("95352563")
             .withEmail("heinz@example.com").build();
     public static final Patient DANIEL = new PatientBuilder().withName("Daniel Meier").withPhone("87652533")
@@ -64,7 +62,7 @@ public class TypicalPatients {
     /**
      * Returns an {@code AddressBook} with all the typical patients.
      */
-    public static AddressBook getTypicalAddressBook() {
+    public static AddressBook getTypicalPatientsAddressBook() {
         AddressBook ab = new AddressBook();
         for (Patient patient : getTypicalPatients()) {
             ab.addPerson(patient);


### PR DESCRIPTION
closes #93.

Main changes:
- `ShiftDays` class is now available for use.
- `Doctor` class now has a `ShiftDays` attribute.
- Ui is now ready to refer to `Doctor`'s `ShiftDays` when displaying shift days.
- Initialising of MediSync previously instantiates contact list with `Person` class. It has now been updated to the correct `Doctor`/`Patient` classes.