### PR TITLE
Add Affn history command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AffiliationHistoryCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AffiliationHistoryCommand.java
@@ -1,0 +1,75 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+import java.util.Set;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.affiliation.Affiliation;
+import seedu.address.model.person.NameMatchesAffiliationPredicate;
+import seedu.address.model.person.Person;
+
+/**
+ * Finds doctors/patients affiliated with patient/doctor.
+ */
+public class AffiliationHistoryCommand extends Command {
+
+    public static final String COMMAND_WORD = "affnh";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds and returns the list of people who "
+        + "are affiliated or once affiliated with the person identified by the index number shown in the  "
+        + "displayed person list. "
+        + "(i.e. returns the doctors of a patient, or the patients of a doctor)\n"
+        + "The index must be a positive integer 1, 2, 3, …\n"
+        + "Parameters: INDEX (must be a positive integer)\n"
+        + "Example: " + COMMAND_WORD + " 2";
+
+    private final Index index;
+
+    /**
+     * Creates an AffiliationCommand to return the affiliation history for the specified {@code Index}
+     */
+    public AffiliationHistoryCommand(Index index) {
+        requireNonNull(index);
+
+        this.index = index;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Person> lastShownList = model.getFilteredPersonList();
+
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        Person personToGetAffiliationsOf = lastShownList.get(index.getZeroBased());
+        Set<Affiliation> affiliationHistory = personToGetAffiliationsOf.getAffiliationHistory();
+
+        model.updateFilteredPersonList(new NameMatchesAffiliationPredicate(affiliationHistory));
+
+        return new CommandResult(
+                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof AffiliationHistoryCommand)) {
+            return false;
+        }
+
+        AffiliationHistoryCommand e = (AffiliationHistoryCommand) other;
+        return index.equals(e.index);
+    }
+
+}

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -43,6 +43,7 @@ public class DeleteCommand extends Command {
 
         Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
         AffiliationModifier.removeAffiliations(personToDelete.getAffiliations(), personToDelete, model);
+        AffiliationModifier.removeAffiliationHistory(personToDelete.getAffiliationHistory(), personToDelete, model);
         model.deletePerson(personToDelete);
         return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, Messages.format(personToDelete)));
     }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -11,6 +11,7 @@ import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.AddAffiliationCommand;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.AffiliationCommand;
+import seedu.address.logic.commands.AffiliationHistoryCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
@@ -82,6 +83,9 @@ public class AddressBookParser {
 
         case AffiliationCommand.COMMAND_WORD:
             return new AffiliationCommandParser().parse(arguments);
+        
+        case AffiliationHistoryCommand.COMMAND_WORD:
+            return new AffiliationHistoryCommandParser().parse(arguments);
 
         case AddAffiliationCommand.COMMAND_WORD:
             return new AddAffiliationCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -83,7 +83,7 @@ public class AddressBookParser {
 
         case AffiliationCommand.COMMAND_WORD:
             return new AffiliationCommandParser().parse(arguments);
-        
+
         case AffiliationHistoryCommand.COMMAND_WORD:
             return new AffiliationHistoryCommandParser().parse(arguments);
 

--- a/src/main/java/seedu/address/logic/parser/AffiliationHistoryCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AffiliationHistoryCommandParser.java
@@ -1,0 +1,32 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.AffiliationHistoryCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new AffiliationCommand object
+ */
+public class AffiliationHistoryCommandParser implements Parser<AffiliationHistoryCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the AffiliationCommand
+     * and returns a AffiliationCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public AffiliationHistoryCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new AffiliationHistoryCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, AffiliationHistoryCommand.MESSAGE_USAGE), pe);
+        }
+    }
+
+}

--- a/src/main/java/seedu/address/model/affiliation/AffiliationModifier.java
+++ b/src/main/java/seedu/address/model/affiliation/AffiliationModifier.java
@@ -73,6 +73,25 @@ public class AffiliationModifier {
     }
 
     /**
+     * Removes the affiliated person from the affiliation history for every
+     * person's affiliation history in the affiliation set provided.
+     * @param affiliationSet
+     * @param affiliatedPerson
+     * @param model
+     */
+    public static void removeAffiliationHistory(Set<Affiliation> affiliationSet, Person affiliatedPerson, Model model) {
+        requireAllNonNull(affiliationSet, affiliatedPerson, model);
+
+        ReadOnlyAddressBook addressBook = model.getAddressBook();
+
+        for (Affiliation affiliation: affiliationSet) {
+            Person otherAffiliatedPerson = AuthenticateAffiliation.findAffiliatedPerson(affiliation, addressBook);
+            assert otherAffiliatedPerson != null;
+            otherAffiliatedPerson.getAffiliationHistory().remove(new Affiliation(affiliatedPerson.getName().fullName));
+        }
+    }
+
+    /**
      * Changes the affiliated person's name to a new name for every
      * person's affiliation in the affiliation set provided.
      *

--- a/src/main/java/seedu/address/model/affiliation/AffiliationModifier.java
+++ b/src/main/java/seedu/address/model/affiliation/AffiliationModifier.java
@@ -75,6 +75,7 @@ public class AffiliationModifier {
     /**
      * Removes the affiliated person from the affiliation history for every
      * person's affiliation history in the affiliation set provided.
+     *
      * @param affiliationSet
      * @param affiliatedPerson
      * @param model
@@ -124,6 +125,7 @@ public class AffiliationModifier {
     /**
      * Changes the affiliated person's name to a new name for every
      * person's affiliation history in the affiliation set provided.
+     *
      * @param affiliationSet The affiliation set that contains all person that needs to change the affiliated
      *                      person from old name to new name.
      * @param oldName The old name that identify the person.

--- a/src/test/java/seedu/address/logic/commands/AffiliationHistoryCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AffiliationHistoryCommandTest.java
@@ -1,0 +1,59 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.affiliation.Affiliation;
+import seedu.address.model.person.NameMatchesAffiliationPredicate;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for AffiliationHistoryCommand.
+ */
+public class AffiliationHistoryCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 1);
+        NameMatchesAffiliationPredicate predicate = new NameMatchesAffiliationPredicate(
+                Set.of(new Affiliation("Benson Meier")));
+        AffiliationHistoryCommand command = new AffiliationHistoryCommand(Index.fromOneBased(1));
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void equals() {
+        final AffiliationHistoryCommand standardCommand = new AffiliationHistoryCommand(Index.fromOneBased(1));
+
+        // same values -> returns true
+        final AffiliationHistoryCommand commandWithSameValues = new AffiliationHistoryCommand(Index.fromOneBased(1));
+        assertTrue(standardCommand.equals(commandWithSameValues));
+
+        // same object -> returns true
+        assertTrue(standardCommand.equals(standardCommand));
+
+        // null -> returns false
+        assertFalse(standardCommand.equals(null));
+
+        // different types -> returns false
+        assertFalse(standardCommand.equals(new ClearCommand()));
+
+        // different name -> returns false
+        assertFalse(standardCommand.equals(new AffiliationHistoryCommand(Index.fromOneBased(2))));
+    }
+
+}

--- a/src/test/java/seedu/address/logic/parser/AffiliationHistoryCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AffiliationHistoryCommandParserTest.java
@@ -1,0 +1,31 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.AffiliationHistoryCommand;
+
+public class AffiliationHistoryCommandParserTest {
+
+    private AffiliationHistoryCommandParser parser = new AffiliationHistoryCommandParser();
+
+    @Test
+    public void parse_emptyArg_throwsParseException() {
+        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                AffiliationHistoryCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_validArgs_returnsAffiliationCommand() {
+        // no leading and trailing whitespaces
+        AffiliationHistoryCommand expectedAffiliationHistoryCommand =
+                new AffiliationHistoryCommand(Index.fromOneBased(1));
+        assertParseSuccess(parser, "1", expectedAffiliationHistoryCommand);
+
+    }
+
+}

--- a/src/test/java/seedu/address/model/affiliation/AffiliationModifierTest.java
+++ b/src/test/java/seedu/address/model/affiliation/AffiliationModifierTest.java
@@ -66,6 +66,20 @@ public class AffiliationModifierTest {
     }
 
     @Test
+    public void removeAffiliationHistory_validParam_success() {
+        Person doctorAlice = new DoctorBuilder().withName("Alice")
+            .withAffiliationHistory("Bob", "Thomas").build();
+        Person patientBob = new PatientBuilder().withName("Bob")
+            .withAffiliations("Alice")
+            .withAffiliationHistory("Alice").build();
+        model.addPerson(doctorAlice);
+        model.addPerson(patientBob);
+
+        AffiliationModifier.removeAffiliationHistory(patientBob.getAffiliationHistory(), patientBob, model);
+        assertFalse(doctorAlice.getAffiliationHistory().contains(new Affiliation(patientBob.getName().fullName)));
+    }
+
+    @Test
     public void nameChangeAffiliation_validParam_success() {
         Person doctorA = new DoctorBuilder().withName("Alice").withAffiliations("Bob")
             .withAffiliationHistory("Bob").build();

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -87,7 +87,7 @@ public class PersonTest {
         editedAlice = new PersonBuilder(ALICE).withRole(VALID_ROLE_BOB).build();
         assertFalse(ALICE.equals(editedAlice));
 
-        // different tags -> returns false
+        // different affiliation -> returns false
         editedAlice = new PersonBuilder(ALICE).withAffiliations(VALID_AFFILIATION_AMY)
         .withAffiliationHistory(VALID_AFFILIATION_AMY).build();
         assertFalse(ALICE.equals(editedAlice));


### PR DESCRIPTION
Add Affiliation history command

- New command 'affnh 1' to show affiliation history of person at index 1
- When a person is deleted, they will be removed from related affiliation histories
- Test cases