### PR TITLE
Disallow changing of role through EditCommand

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -106,8 +106,6 @@ public class EditCommand extends Command {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
 
-        assert !this.editPersonDescriptor.isRoleEdited();
-
         if (this.editPersonDescriptor.isNameEdited()) {
             AffiliationModifier.nameChangeAffiliations(personToEdit.getAffiliations(), personToEdit.getName(),
                     editedPerson.getName(), model);

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -6,7 +6,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_AFFILIATION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ROLE;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.Collections;
@@ -47,7 +46,6 @@ public class EditCommand extends Command {
             + "[" + PREFIX_NAME + "NAME] "
             + "[" + PREFIX_PHONE + "PHONE] "
             + "[" + PREFIX_EMAIL + "EMAIL] "
-            + "[" + PREFIX_ROLE + "ROLE] "
             + "[" + PREFIX_AFFILIATION + "AFFILIATION]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_PHONE + "91234567 "
@@ -57,8 +55,7 @@ public class EditCommand extends Command {
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_PERSON =
             "This person already exists in the contact list. Please use a different name.";
-    public static final String MESSAGE_EDIT_ROLE_CONTAIN_AFFILIATION =
-            "This person contains affiliations. Changing of Role is not allowed.";
+    public static final String MESSAGE_EDIT_ROLE_NOT_ALLOW = "Editing of role is not allowed.";
 
     private final Index index;
     private final EditPersonDescriptor editPersonDescriptor;
@@ -109,6 +106,8 @@ public class EditCommand extends Command {
         if (!personToEdit.isSamePerson(editedPerson) && model.hasPerson(editedPerson)) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
+
+        assert !this.editPersonDescriptor.isRoleEdited();
 
         if (this.editPersonDescriptor.isNameEdited()) {
             AffiliationModifier.nameChangeAffiliations(personToEdit.getAffiliations(), personToEdit.getName(),
@@ -307,7 +306,7 @@ public class EditCommand extends Command {
         }
         /**
          * Adds {@code affiliations} to this object's {@code affiliations}.
-         * @param affiliations
+         * @param affiliations the affiliations to add to affiliation history.
          */
         public void addAffiliationsToHistory(Set<Affiliation> affiliations) {
             if (this.affiliationHistory == null) {

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -107,8 +107,6 @@ public class EditCommand extends Command {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
 
-        assert !this.editPersonDescriptor.isRoleEdited();
-
         if (this.editPersonDescriptor.isNameEdited()) {
             AffiliationModifier.nameChangeAffiliations(personToEdit.getAffiliations(), personToEdit.getName(),
                     editedPerson.getName(), model);

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -48,6 +48,10 @@ public class EditCommandParser implements Parser<EditCommand> {
 
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
 
+        if (argMultimap.getValue(PREFIX_ROLE).isPresent()) {
+            throw new ParseException(EditCommand.MESSAGE_EDIT_ROLE_NOT_ALLOW);
+        }
+
         if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
             editPersonDescriptor.setName(ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()));
         }
@@ -57,9 +61,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         if (argMultimap.getValue(PREFIX_EMAIL).isPresent()) {
             editPersonDescriptor.setEmail(ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get()));
         }
-        if (argMultimap.getValue(PREFIX_ROLE).isPresent()) {
-            editPersonDescriptor.setRole(ParserUtil.parseRole(argMultimap.getValue(PREFIX_ROLE).get()));
-        }
+
         parseAffiliationsForEdit(argMultimap.getAllValues(PREFIX_AFFILIATION))
                 .ifPresent(editPersonDescriptor::setAffiliations);
         parseAffiliationsForEdit(argMultimap.getAllValues(PREFIX_AFFILIATION))

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -76,7 +76,8 @@ public class CommandTestUtil {
         DESC_AMY = new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY)
                 .withPhone(VALID_PHONE_AMY).withEmail(VALID_EMAIL_AMY).withRole(VALID_ROLE_AMY)
                 .withAffiliations(VALID_AFFILIATION_BOB)
-                .withAffiliationHistory(VALID_AFFILIATION_BOB).build();
+                .withAffiliationHistory(VALID_AFFILIATION_BOB)
+                .withShiftDays(VALID_SHIFTDAYS_AMY).build();
         DESC_BOB = new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB)
                 .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB).withRole(VALID_ROLE_BOB)
                 .withAffiliations(VALID_AFFILIATION_AMY, VALID_AFFILIATION_BOB)

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_AFFILIATION_CAT;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
@@ -15,6 +16,10 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
@@ -24,8 +29,10 @@ import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.affiliation.Affiliation;
 import seedu.address.model.person.Doctor;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.ShiftDays;
 import seedu.address.model.person.Staff;
 import seedu.address.testutil.DoctorBuilder;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
@@ -183,6 +190,19 @@ public class EditCommandTest {
 
         // different descriptor -> returns false
         assertFalse(standardCommand.equals(new EditCommand(INDEX_FIRST_PERSON, DESC_BOB)));
+
+        // different affiliation history -> returns false
+        EditPersonDescriptor differentAffiliationHistoryDescriptor = new EditPersonDescriptor(DESC_AMY);
+        Set<Affiliation> differentAffiliationHistory = new HashSet<>();
+        differentAffiliationHistory.add(new Affiliation(VALID_AFFILIATION_CAT));
+        differentAffiliationHistoryDescriptor.setAffiliationHistory(differentAffiliationHistory);
+        assertFalse(standardCommand.equals(new EditCommand(INDEX_FIRST_PERSON, differentAffiliationHistoryDescriptor)));
+
+        // different shiftDay -> returns false
+        EditPersonDescriptor differentShiftDayDescriptor = new EditPersonDescriptor(DESC_AMY);
+        ShiftDays differentShiftDay = new ShiftDays(new HashSet<>(Arrays.asList(2, 3, 4)));
+        differentShiftDayDescriptor.setShiftDays(differentShiftDay);
+        assertFalse(standardCommand.equals(new EditCommand(INDEX_FIRST_PERSON, differentAffiliationHistoryDescriptor)));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -9,7 +9,6 @@ import static seedu.address.logic.commands.CommandTestUtil.INVALID_AFFILIATION_D
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_ROLE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
@@ -42,7 +41,6 @@ import seedu.address.model.affiliation.Affiliation;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
-import seedu.address.model.person.Role;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 
 public class EditCommandParserTest {
@@ -53,6 +51,12 @@ public class EditCommandParserTest {
             String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE);
 
     private EditCommandParser parser = new EditCommandParser();
+
+    @Test
+    public void parse_changeRole_failure() {
+        // Edit of Role not allowed
+        assertParseFailure(parser, "1 r/Patient", EditCommand.MESSAGE_EDIT_ROLE_NOT_ALLOW);
+    }
 
     @Test
     public void parse_missingParts_failure() {
@@ -86,7 +90,6 @@ public class EditCommandParserTest {
         assertParseFailure(parser, "1" + INVALID_NAME_DESC, Name.MESSAGE_CONSTRAINTS); // invalid name
         assertParseFailure(parser, "1" + INVALID_PHONE_DESC, Phone.MESSAGE_CONSTRAINTS); // invalid phone
         assertParseFailure(parser, "1" + INVALID_EMAIL_DESC, Email.MESSAGE_CONSTRAINTS); // invalid email
-        assertParseFailure(parser, "1" + INVALID_ROLE_DESC, Role.MESSAGE_CONSTRAINTS); // invalid role
         assertParseFailure(parser, "1" + INVALID_AFFILIATION_DESC,
                 Affiliation.MESSAGE_CONSTRAINTS); // invalid affiliation
 
@@ -112,10 +115,10 @@ public class EditCommandParserTest {
     public void parse_allFieldsSpecified_success() {
         Index targetIndex = INDEX_SECOND_PERSON;
         String userInput = targetIndex.getOneBased() + PHONE_DESC_BOB + AFFILIATION_DESC_AMY
-                + EMAIL_DESC_AMY + ROLE_DESC_AMY + NAME_DESC_AMY + AFFILIATION_DESC_BOB;
+                + EMAIL_DESC_AMY + NAME_DESC_AMY + AFFILIATION_DESC_BOB;
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY)
-                .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_AMY).withRole(VALID_ROLE_AMY)
+                .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_AMY)
                 .withAffiliations(VALID_AFFILIATION_AMY, VALID_AFFILIATION_BOB)
                 .withAffiliationHistory(VALID_AFFILIATION_AMY, VALID_AFFILIATION_BOB).build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
@@ -156,12 +159,6 @@ public class EditCommandParserTest {
         expectedCommand = new EditCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
-        // role
-        userInput = targetIndex.getOneBased() + ROLE_DESC_AMY;
-        descriptor = new EditPersonDescriptorBuilder().withRole(VALID_ROLE_AMY).build();
-        expectedCommand = new EditCommand(targetIndex, descriptor);
-        assertParseSuccess(parser, userInput, expectedCommand);
-
         // affiliations
         userInput = targetIndex.getOneBased() + AFFILIATION_DESC_BOB;
         descriptor = new EditPersonDescriptorBuilder().withAffiliations(VALID_AFFILIATION_BOB)
@@ -195,11 +192,11 @@ public class EditCommandParserTest {
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ROLE));
 
         // multiple invalid values
-        userInput = targetIndex.getOneBased() + INVALID_PHONE_DESC + INVALID_ROLE_DESC + INVALID_EMAIL_DESC
-                + INVALID_PHONE_DESC + INVALID_ROLE_DESC + INVALID_EMAIL_DESC;
+        userInput = targetIndex.getOneBased() + INVALID_PHONE_DESC + INVALID_EMAIL_DESC
+                + INVALID_PHONE_DESC + INVALID_EMAIL_DESC;
 
         assertParseFailure(parser, userInput,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ROLE));
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE, PREFIX_EMAIL));
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
@@ -37,7 +37,6 @@ public class EditPersonDescriptorBuilder {
         descriptor.setName(person.getName());
         descriptor.setPhone(person.getPhone());
         descriptor.setEmail(person.getEmail());
-        descriptor.setRole(person.getRole());
         descriptor.setAffiliations(person.getAffiliations());
         descriptor.setAffiliationHistory(person.getAffiliationHistory());
         if (person instanceof Staff) {

--- a/src/test/java/seedu/address/testutil/PersonUtil.java
+++ b/src/test/java/seedu/address/testutil/PersonUtil.java
@@ -48,7 +48,6 @@ public class PersonUtil {
         descriptor.getName().ifPresent(name -> sb.append(PREFIX_NAME).append(name.fullName).append(" "));
         descriptor.getPhone().ifPresent(phone -> sb.append(PREFIX_PHONE).append(phone.value).append(" "));
         descriptor.getEmail().ifPresent(email -> sb.append(PREFIX_EMAIL).append(email.value).append(" "));
-        descriptor.getRole().ifPresent(role -> sb.append(PREFIX_ROLE).append(role.value).append(" "));
         if (descriptor.getAffiliations().isPresent()) {
             Set<Affiliation> affiliations = descriptor.getAffiliations().get();
             if (affiliations.isEmpty()) {


### PR DESCRIPTION
fixes #101
Disallow changing of role through EditCommand

- Edit command no longer accept r/ to change role.
- Role will not be allowed to change by any means after a person is created.
- Test cases are updated to not contain Role Prefix.