### PR TITLE
Allow text wrap in UI

### DIFF
--- a/src/main/java/seedu/address/ui/InformationWindow.java
+++ b/src/main/java/seedu/address/ui/InformationWindow.java
@@ -186,8 +186,10 @@ public class InformationWindow extends UiPart<Region> {
         clearAffiliations();
         for (Affiliation affiliation : person.getAffiliations()) {
             String name = affiliation.toString();
-            Label label = new Label("- " + name);
+            Label label = new Label("-\u00A0" + name);
             label.getStyleClass().add("information-affn-list");
+            label.setMinHeight(Region.USE_PREF_SIZE);
+            label.setWrapText(true);
             affnListBlock.getChildren().add(label);
         }
 
@@ -223,6 +225,7 @@ public class InformationWindow extends UiPart<Region> {
      */
     private void setNok(Patient patient) {
         clearNok();
+
         nokBlock.setVisible(true);
         nokBlock.setManaged(true);
         nokBlock.setStyle("-fx-border-color: #BBBBBB; -fx-border-width: 2 0 0 0;");
@@ -231,9 +234,9 @@ public class InformationWindow extends UiPart<Region> {
         NextOfKin nok = patient.getNextOfKin();
         if (nok.isPresent()) {
             adjustNokPresence(true);
-            nokName.setText("Name: " + nok.getName().fullName);
-            nokPhone.setText("Phone no.: " + nok.getPhone().value);
-            nokRelationship.setText("Relationship: " + nok.getRelationship().relationship);
+            nokName.setText("Name:\u00A0" + nok.getName().fullName);
+            nokPhone.setText("Phone\u00A0no.:\u00A0" + nok.getPhone().value);
+            nokRelationship.setText("Relationship:\u00A0" + nok.getRelationship().relationship);
         } else {
             adjustNokPresence(false);
             nokNotPresent.setText("MISSING. Please add an NOK for this patient.");
@@ -282,8 +285,10 @@ public class InformationWindow extends UiPart<Region> {
         specListHeader.setText("Specialisations:");
         for (Specialisation specialisation : doctor.getSpecialisations()) {
             String spec = specialisation.toString();
-            Label label = new Label("- " + spec);
+            Label label = new Label("-\u00A0" + spec);
             label.getStyleClass().add("information-spec-list");
+            label.setWrapText(true);
+            label.setMinHeight(Region.USE_PREF_SIZE);
             specListBlock.getChildren().add(label);
         }
 

--- a/src/main/resources/view/InformationWindow.fxml
+++ b/src/main/resources/view/InformationWindow.fxml
@@ -8,7 +8,7 @@
 
 <ScrollPane fitToHeight="true" fitToWidth="true" hbarPolicy="NEVER"
             style="-fx-background-color: transparent; -fx-border-width: 0; -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.5), 10, 0, 0, 0);"
-            styleClass="scroll-pane" xmlns="17" xmlns:fx="http://javafx.com/fxml/1">
+            styleClass="scroll-pane" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
     <content>
         <VBox fx:id="fullWindow" minHeight="0.0">
             <children>

--- a/src/main/resources/view/InformationWindow.fxml
+++ b/src/main/resources/view/InformationWindow.fxml
@@ -8,11 +8,12 @@
 
 <ScrollPane fitToHeight="true" fitToWidth="true" hbarPolicy="NEVER"
             style="-fx-background-color: transparent; -fx-border-width: 0; -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.5), 10, 0, 0, 0);"
-            styleClass="scroll-pane" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
+            styleClass="scroll-pane" xmlns="17" xmlns:fx="http://javafx.com/fxml/1">
     <content>
         <VBox fx:id="fullWindow" minHeight="0.0">
             <children>
-                <Label fx:id="name" minWidth="350.0" prefWidth="350.0" styleClass="information-name">
+                <Label fx:id="name" minHeight="-Infinity" minWidth="350.0" styleClass="information-name"
+                       wrapText="true">
                     <VBox.margin>
                         <Insets left="20.0" top="15.0"/>
                     </VBox.margin>
@@ -25,7 +26,7 @@
                         <Insets left="10.0" right="10.0"/>
                     </padding>
                 </Label>
-                <Label fx:id="email" styleClass="information-email">
+                <Label fx:id="email" minHeight="-Infinity" styleClass="information-email" wrapText="true">
                     <padding>
                         <Insets left="10.0" right="10.0"/>
                     </padding>
@@ -97,9 +98,11 @@
                     <children>
                         <Label fx:id="nokHeader" styleClass="information-nok"/>
                         <Label fx:id="nokNotPresent" styleClass="information-nok-missing"/>
-                        <Label fx:id="nokName" styleClass="information-nok-name"/>
-                        <Label fx:id="nokPhone" styleClass="information-nok-phone"/>
-                        <Label fx:id="nokRelationship" styleClass="information-nok-relationship"/>
+                        <Label fx:id="nokName" minHeight="-Infinity" styleClass="information-nok-name" wrapText="true"/>
+                        <Label fx:id="nokPhone" minHeight="-Infinity" styleClass="information-nok-phone"
+                               wrapText="true"/>
+                        <Label fx:id="nokRelationship" minHeight="-Infinity" styleClass="information-nok-relationship"
+                               wrapText="true"/>
                     </children>
                     <VBox.margin>
                         <Insets left="20.0" right="20.0" top="15.0"/>


### PR DESCRIPTION
![image](https://github.com/AY2324S1-CS2103-T16-2/tp/assets/96569391/aacfe666-3624-4e0a-81ae-a8f92bba7d48)

Currently, if a long name is used, not those that are extreme i.e. 1000 characters, it will truncate in the information window even at maximised window size. Long names are perfectly valid and are something that should be catered for.
